### PR TITLE
Revise wording for `proxy_view` and related facilities

### DIFF
--- a/docs/spec/make_proxy_view.md
+++ b/docs/spec/make_proxy_view.md
@@ -12,7 +12,7 @@ template <facade F, class T>
 proxy_view<F> make_proxy_view(T& value) noexcept;
 ```
 
-Creates a `proxy_view<F>` object containing a value `p` of type `observer-ptr<T>`, where `*p` is direct-non-list-initialized with `std::addressof(value)`. If [`proxiable_target<T, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
+Creates a `proxy_view<F>` object containing a value `p` of type `observer-ptr<T>`, where `p` is direct-non-list-initialized with `std::addressof(value)`. If [`proxiable_target<T, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 
 ## Return Value
 

--- a/docs/spec/make_proxy_view.md
+++ b/docs/spec/make_proxy_view.md
@@ -12,7 +12,7 @@ template <facade F, class T>
 proxy_view<F> make_proxy_view(T& value) noexcept;
 ```
 
-Creates a `proxy_view<F>` object containing a value `p` of type `observer-ptr<T>`, where `*p` is direct-non-list-initialized with `&value`. If [`proxiable_target<T, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
+Creates a `proxy_view<F>` object containing a value `p` of type `observer-ptr<T>`, where `*p` is direct-non-list-initialized with `std::addressof(value)`. If [`proxiable_target<T, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 
 ## Return Value
 

--- a/docs/spec/proxiable_target.md
+++ b/docs/spec/proxiable_target.md
@@ -7,7 +7,7 @@
 
 ```cpp
 template <class T, class F>
-concept proxiable_target = proxiable<observer-ptr<T>, F>;
+concept proxiable_target = proxiable<observer-ptr<T>, observer_facade<F>>;
 ```
 
 See [`make_proxy_view`](make_proxy_view.md) for the definition of the exposition-only class template *observer-ptr*.


### PR DESCRIPTION
**Changes**

- `proxiable_target`'s spec was wrong (see the [correct definition in `proxy.h`](https://github.com/ngcpp/proxy/blob/bcbe0c792cd42cb48edfbbdb1e272255cbe73cae/include/proxy/v4/proxy.h#L1785-L1788)).
- Avoid using `operator &` `make_proxy_view()`'s wording.

No functional changes.