### PR TITLE
Update mkdocs dependency version

### DIFF
--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -1,10 +1,10 @@
-markdown==3.8.2
+markdown==3.10.2
 mdx_truly_sane_lists==1.3
 mkdocs-awesome-pages-plugin==2.10.1
 mkdocs-exclude==1.0.2
-mkdocs-git-revision-date-localized-plugin==1.4.7
-mkdocs-material==9.6.16
+mkdocs-git-revision-date-localized-plugin==1.5.1
+mkdocs-material==9.7.6
 mkdocs-open-in-new-tab==1.0.8
 mkdocs==1.6.1
-pygments==2.19.2
-pymdown-extensions==10.16.1
+pygments==2.20.0
+pymdown-extensions==10.21.2

--- a/mkdocs/requirements.txt
+++ b/mkdocs/requirements.txt
@@ -6,4 +6,5 @@ mkdocs-git-revision-date-localized-plugin==1.4.7
 mkdocs-material==9.6.16
 mkdocs-open-in-new-tab==1.0.8
 mkdocs==1.6.1
+pygments==2.19.2
 pymdown-extensions==10.16.1


### PR DESCRIPTION
The mkdocs pipeline [started to fail recently](https://github.com/mingxwa/proxy/actions/runs/24300298920/job/70952395524). This is because an indirect dependency (pygments) introduced a breaking change.

**Changes**

- Explicitly added `pygments` to `requirements.txt`.
- Updated the version of other dependencies.