### PR TITLE
Update toolchain

### DIFF
--- a/.github/workflows/bvt-appleclang.yml
+++ b/.github/workflows/bvt-appleclang.yml
@@ -3,7 +3,7 @@ on:
 
 jobs:
   bvt-appleclang:
-    runs-on: macos-15
+    runs-on: macos-26
     steps:
     - uses: actions/checkout@v4
 

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
 
+env:
+  CLANG_VERSION: 22
+
 jobs:
   bvt-clang:
     runs-on: ubuntu-24.04
@@ -12,30 +15,30 @@ jobs:
 
     - name: install clang
       run: |
-        curl https://apt.llvm.org/llvm.sh | sudo bash -s -- 21
-        sudo apt install -y clang-21 libc++-21-dev clang-format-21
-        cat <<'EOF' >> "$GITHUB_ENV"
-        CC=clang-21
-        CXX=clang++-21
-        CXXFLAGS=-stdlib=libc++
-        EOF
+        curl https://apt.llvm.org/llvm.sh | sudo bash -s -- "$CLANG_VERSION"
+        sudo apt install -y "clang-$CLANG_VERSION" "libc++-$CLANG_VERSION-dev" "clang-format-$CLANG_VERSION"
+        {
+          echo "CC=clang-$CLANG_VERSION"
+          echo "CXX=clang++-$CLANG_VERSION"
+          echo "CXXFLAGS=-stdlib=libc++"
+        } >> "$GITHUB_ENV"
 
     - name: check compiler version
       run: |
         "$CXX" --version
 
-    - name: build and run test with clang 21 on cmake
+    - name: build and run test with clang ${{ env.CLANG_VERSION }} on cmake
       run: |
         cmake -B build-cmake -GNinja -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=TRUE
         mapfile -t FILES < <(find include tests benchmarks build-cmake/examples_from_docs tools -type f \( -name '*.h' -o -name '*.ixx' -o -name '*.cpp' \))
         echo "Running clang-format on ${#FILES[@]} files: ${FILES[*]}"
-        clang-format-21 --dry-run --Werror "${FILES[@]}"
+        "clang-format-$CLANG_VERSION" --dry-run --Werror "${FILES[@]}"
         cmake --build build-cmake -j
         ctest --test-dir build-cmake -j
         mkdir build-cmake/drop
         bash ./tools/dump_build_env.sh "$CXX" build-cmake/drop/env-info.json
 
-    - name: build and run test with clang 21 on meson
+    - name: build and run test with clang ${{ env.CLANG_VERSION }} on meson
       run: |
         meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled --force-fallback-for=fmt
         meson test -C build-meson

--- a/.github/workflows/bvt-compatibility.yml
+++ b/.github/workflows/bvt-compatibility.yml
@@ -15,6 +15,7 @@ jobs:
           - {family: clang, version: 18, modules: false}
           - {family: clang, version: 19, modules: false}
           - {family: clang, version: 20, modules: true}
+          - {family: clang, version: 21, modules: true}
 
     steps:
     - uses: actions/checkout@v4
@@ -31,6 +32,9 @@ jobs:
     - name: install clang
       if: ${{ matrix.compiler.family == 'clang' }}
       run: |
+        if [ '${{ matrix.compiler.version }}' -ge 21 ]; then
+          curl https://apt.llvm.org/llvm.sh | sudo bash -s -- '${{ matrix.compiler.version }}'
+        fi
         sudo apt install -y 'clang-${{ matrix.compiler.version }}' 'clang-tools-${{ matrix.compiler.version }}' 'libc++-${{ matrix.compiler.version }}-dev' 'libc++abi-${{ matrix.compiler.version }}-dev'
         cat <<'EOF' >> "$GITHUB_ENV"
         CC=clang-${{ matrix.compiler.version }}

--- a/.github/workflows/bvt-nvhpc.yml
+++ b/.github/workflows/bvt-nvhpc.yml
@@ -1,6 +1,9 @@
 on:
   workflow_call:
 
+env:
+  NVHPC_VERSION: 26.3
+
 jobs:
   bvt-nvhpc:
     runs-on: ubuntu-24.04
@@ -14,18 +17,18 @@ jobs:
     #   # FIXME: install from upstream once https://github.com/mesonbuild/meson/pull/15353 is released
     #   run: pipx install git+https://github.com/mesonbuild/meson@02b85a846629090a0c7f18e860bab0a10ea4349b
 
-    - name: install NVHPC 25.11
+    - name: install NVHPC ${{ env.NVHPC_VERSION }}
       run: |
         curl https://developer.download.nvidia.com/hpc-sdk/ubuntu/DEB-GPG-KEY-NVIDIA-HPC-SDK | sudo gpg --dearmor -o /usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg
         echo 'deb [signed-by=/usr/share/keyrings/nvidia-hpcsdk-archive-keyring.gpg] https://developer.download.nvidia.com/hpc-sdk/ubuntu/amd64 /' | sudo tee /etc/apt/sources.list.d/nvhpc.list
         sudo apt-get update -y
-        sudo apt-get install -y nvhpc-25-11
-        cat<<'EOF' >> "$GITHUB_ENV"
-        CC=/opt/nvidia/hpc_sdk/Linux_x86_64/25.11/compilers/bin/nvc
-        CXX=/opt/nvidia/hpc_sdk/Linux_x86_64/25.11/compilers/bin/nvc++
-        EOF
+        sudo apt-get install -y "nvhpc-${NVHPC_VERSION/./-}"
+        {
+          echo "CC=/opt/nvidia/hpc_sdk/Linux_x86_64/$NVHPC_VERSION/compilers/bin/nvc"
+          echo "CXX=/opt/nvidia/hpc_sdk/Linux_x86_64/$NVHPC_VERSION/compilers/bin/nvc++"
+        } >> "$GITHUB_ENV"
 
-    - name: build and run test with NVHPC 25.11 on cmake
+    - name: build and run test with NVHPC ${{ env.NVHPC_VERSION }} on cmake
       run: |
         cmake -B build-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=FALSE
         cmake --build build-cmake -j
@@ -34,7 +37,7 @@ jobs:
         chmod +x tools/dump_build_env.sh
         ./tools/dump_build_env.sh "$CXX" build-cmake/drop/env-info.json
 
-    # - name: build and run test with NVHPC 25.11 on meson
+    # - name: build and run test with NVHPC ${{ env.NVHPC_VERSION }} on meson
     #   run: |
     #     meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled --force-fallback-for=fmt
     #     meson test -C build-meson

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -2,8 +2,8 @@ project(msft_proxy_benchmarks)
 
 FetchContent_Declare(
   benchmark
-  URL https://github.com/google/benchmark/archive/refs/tags/v1.9.4.tar.gz
-  URL_HASH SHA256=b334658edd35efcf06a99d9be21e4e93e092bd5f95074c1673d5c8705d95c104
+  URL https://github.com/google/benchmark/archive/refs/tags/v1.9.5.tar.gz
+  URL_HASH SHA256=9631341c82bac4a288bef951f8b26b41f69021794184ece969f8473977eaa340
 )
 set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "Disable tests for google benchmark")
 set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "Disable google benchmark unit tests")


### PR DESCRIPTION
**Changes**

- Update macOS version to 2026
- Update clang version to 22
- Updated NVHPC version to 26.3
- Added regression test for clang 21
- Updated Google benchmark to 1.9.5