### PR TITLE
Fix typo in benchmarks

### DIFF
--- a/benchmarks/proxy_operation_benchmark.cpp
+++ b/benchmarks/proxy_operation_benchmark.cpp
@@ -121,7 +121,7 @@ void BM_LargeObjectInvocationViaVirtualFunction(benchmark::State& state) {
 
 void BM_LargeObjectInvocationViaVirtualFunction_Shared(
     benchmark::State& state) {
-  auto data = GenerateLargeObjectVirtualFunctionTestData();
+  auto data = GenerateLargeObjectVirtualFunctionTestData_Shared();
   for (auto _ : state) {
     for (auto& p : data) {
       int result = p->Fun();


### PR DESCRIPTION
As tested locally, the fix even makes the numbers look better.