### PR TITLE
Deprecate `basic_facade_builder::add_facade<F, true>`

### DIFF
--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -2017,6 +2017,14 @@ using merge_facade_conv_t = typename add_substitution_conv<
         ? F::relocatability
         : constraint_level::none>::type;
 
+template <bool WithSubstitution>
+struct add_facade_deprecation_traits : std::bool_constant<WithSubstitution> {};
+template <>
+struct [[deprecated(
+    "basic_facade_builder::add_facade<F, true> is deprecated; use "
+    "basic_facade_builder::add_facade_with_substitution<F> instead.")]]
+add_facade_deprecation_traits<true> : std::bool_constant<true> {};
+
 } // namespace details
 
 template <class Cs, class Rs, std::size_t MaxSize, std::size_t MaxAlign,
@@ -2048,7 +2056,18 @@ struct basic_facade_builder {
   using add_reflection = add_indirect_reflection<R>;
   template <facade F, bool WithSubstitution = false>
   using add_facade = basic_facade_builder<
-      details::merge_facade_conv_t<Cs, F, WithSubstitution>,
+      details::merge_facade_conv_t<
+          Cs, F,
+          details::add_facade_deprecation_traits<WithSubstitution>::value>,
+      details::merge_tuple_t<Rs, typename F::reflection_types>,
+      details::merge_size(MaxSize, F::max_size),
+      details::merge_size(MaxAlign, F::max_align),
+      details::merge_constraint(Copyability, F::copyability),
+      details::merge_constraint(Relocatability, F::relocatability),
+      details::merge_constraint(Destructibility, F::destructibility)>;
+  template <facade F>
+  using add_facade_with_substitution = basic_facade_builder<
+      details::merge_facade_conv_t<Cs, F, true>,
       details::merge_tuple_t<Rs, typename F::reflection_types>,
       details::merge_size(MaxSize, F::max_size),
       details::merge_size(MaxAlign, F::max_align),

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -167,10 +167,11 @@ struct TestSharedStringable
       ::add_direct_reflection<LifetimeModelReflector>            //
       ::build {};
 
-struct TestWeakSharedStringable : pro::facade_builder                      //
-                                  ::add_facade<TestSharedStringable, true> //
-                                  ::add_skill<pro::skills::as_weak>        //
-                                  ::build {};
+struct TestWeakSharedStringable
+    : pro::facade_builder                                  //
+      ::add_facade_with_substitution<TestSharedStringable> //
+      ::add_skill<pro::skills::as_weak>                    //
+      ::build {};
 
 static_assert(pro::proxiable<int*, TestSharedStringable>);
 static_assert(!pro::proxiable<int*, TestWeakSharedStringable>);

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -28,7 +28,7 @@ struct TestTrivialFacade
 
 struct TestRttiFacade : pro::facade_builder                           //
                         ::add_direct_reflection<utils::RttiReflector> //
-                        ::add_facade<TestFacade, true>                //
+                        ::add_facade_with_substitution<TestFacade>    //
                         ::build {};
 
 // Additional static asserts for substitution

--- a/tests/proxy_view_tests.cpp
+++ b/tests/proxy_view_tests.cpp
@@ -139,9 +139,9 @@ TEST(ProxyViewTests, TestOverloadShadowing) {
 
 TEST(ProxyViewTests, TestSubstitution_FromNull) {
   struct TestFacade1 : pro::facade_builder::build {};
-  struct TestFacade2 : pro::facade_builder             //
-                       ::add_facade<TestFacade1, true> // Supports substitution
-                       ::add_skill<pro::skills::as_view> //
+  struct TestFacade2 : pro::facade_builder                         //
+                       ::add_facade_with_substitution<TestFacade1> //
+                       ::add_skill<pro::skills::as_view>           //
                        ::build {};
   pro::proxy<TestFacade2> p1;
   pro::proxy_view<TestFacade2> p2 = p1;
@@ -158,8 +158,8 @@ TEST(ProxyViewTests, TestSubstitution_FromValue) {
         ::build {};
   struct TestFacade2 : pro::facade_builder                               //
                        ::support_copy<pro::constraint_level::nontrivial> //
-                       ::add_facade<TestFacade1, true> // Supports substitution
-                       ::add_skill<pro::skills::as_view> //
+                       ::add_facade_with_substitution<TestFacade1>       //
+                       ::add_skill<pro::skills::as_view>                 //
                        ::build {};
   pro::proxy<TestFacade2> p1 = pro::make_proxy<TestFacade2>(123);
   pro::proxy_view<TestFacade2> p2 = p1;


### PR DESCRIPTION
As per user feedback, the syntax of `basic_facade_builder::add_facade<F, true>` is not intuitive enough. This PR deprecated that usage, and introduced a more explicit API `add_facade_with_substitution`.

**Changes**

- Implemented `details::add_facade_deprecation_traits` to generate deprecation diagnostics.
- Added new API `basic_facade_builder::add_facade_with_substitution`.
- Updated unit tests accordingly.