### PR TITLE
Specialize `instantiated_t` for `std::tuple` to improve performance

### DIFF
--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -153,14 +153,16 @@ struct instantiated_traits<T, TL, std::index_sequence<Is...>, Args...>
     : std::type_identity<T<Args..., std::tuple_element_t<Is, TL>...>> {};
 
 template <template <class...> class T, class TL, class... Args>
-struct instantiated_traits_helper : instantiated_traits<
-    T, TL, std::make_index_sequence<std::tuple_size_v<TL>>, Args...> {};
+struct instantiated_traits_helper
+    : instantiated_traits<
+          T, TL, std::make_index_sequence<std::tuple_size_v<TL>>, Args...> {};
 template <template <class...> class T, class... Ts, class... Args>
-struct instantiated_traits_helper<T, std::tuple<Ts...>, Args...> 
+struct instantiated_traits_helper<T, std::tuple<Ts...>, Args...>
     : std::type_identity<T<Args..., Ts...>> {};
 
 template <template <class...> class T, class TL, class... Args>
-using instantiated_t = typename instantiated_traits_helper<T, TL, Args...>::type;
+using instantiated_t =
+    typename instantiated_traits_helper<T, TL, Args...>::type;
 
 enum class qualifier_type { lv, const_lv, rv, const_rv };
 template <class T, qualifier_type Q>

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -151,9 +151,16 @@ template <template <class...> class T, class TL, std::size_t... Is,
           class... Args>
 struct instantiated_traits<T, TL, std::index_sequence<Is...>, Args...>
     : std::type_identity<T<Args..., std::tuple_element_t<Is, TL>...>> {};
+
 template <template <class...> class T, class TL, class... Args>
-using instantiated_t = typename instantiated_traits<
-    T, TL, std::make_index_sequence<std::tuple_size_v<TL>>, Args...>::type;
+struct instantiated_traits_helper : instantiated_traits<
+    T, TL, std::make_index_sequence<std::tuple_size_v<TL>>, Args...> {};
+template <template <class...> class T, class... Ts, class... Args>
+struct instantiated_traits_helper<T, std::tuple<Ts...>, Args...> 
+    : std::type_identity<T<Args..., Ts...>> {};
+
+template <template <class...> class T, class TL, class... Args>
+using instantiated_t = typename instantiated_traits_helper<T, TL, Args...>::type;
 
 enum class qualifier_type { lv, const_lv, rv, const_rv };
 template <class T, qualifier_type Q>

--- a/include/proxy/v4/proxy.h
+++ b/include/proxy/v4/proxy.h
@@ -151,7 +151,6 @@ template <template <class...> class T, class TL, std::size_t... Is,
           class... Args>
 struct instantiated_traits<T, TL, std::index_sequence<Is...>, Args...>
     : std::type_identity<T<Args..., std::tuple_element_t<Is, TL>...>> {};
-
 template <template <class...> class T, class TL, class... Args>
 struct instantiated_traits_helper
     : instantiated_traits<
@@ -159,7 +158,6 @@ struct instantiated_traits_helper
 template <template <class...> class T, class... Ts, class... Args>
 struct instantiated_traits_helper<T, std::tuple<Ts...>, Args...>
     : std::type_identity<T<Args..., Ts...>> {};
-
 template <template <class...> class T, class TL, class... Args>
 using instantiated_t =
     typename instantiated_traits_helper<T, TL, Args...>::type;


### PR DESCRIPTION
## Summary

Add a `std::tuple` specialization to `instantiated_t` to improve compile-time performance, as discussed in [#30](https://github.com/ngcpp/proxy/issues/30).

The new implementation uses `instantiated_traits_helper` that forwards to the generic path except for `std::tuple`, where it directly unpacks the types.

## Performance

[Benchmarks](https://github.com/Kim-J-Smith/proxy/actions/runs/24950018061) show significant improvements, especially with many conventions:

| Conventions | Old (μs) | New (μs) | Improvement |
|-------------|----------|----------|--------------|
| 3           | 28,248   | 25,756   | +9.7%        |
| 10          | 50,087   | 38,855   | +28.9%       |
| 30          | 155,814  | 91,322   | +70.6%       |
| 100         | 1,711,836| 387,900  | +341.3%      |
| 200         | 10,181,265| 1,066,715| +854.5%      |

## Testing

No new unit tests required -- the `std::tuple` case is already covered by existing usage.