### PR TITLE
Add coverage for freestanding

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -5,6 +5,10 @@ common --enable_platform_specific_config
 # Default Build Options
 build --features=external_include_paths
 
+# Freestanding Configuration
+build:freestanding --cxxopt=-ffreestanding --cxxopt=-fno-exceptions --cxxopt=-fno-rtti
+build:freestanding --linkopt=-nodefaultlibs --linkopt=-lc
+
 # Platform-Specific Toolchain Overrides
 build:linux --repo_env=BAZEL_CXXOPTS=-std=c++20
 build:macos --repo_env=BAZEL_CXXOPTS=-std=c++20

--- a/.github/workflows/bvt-appleclang.yml
+++ b/.github/workflows/bvt-appleclang.yml
@@ -22,26 +22,37 @@ jobs:
 
     - name: Build and run test with AppleClang on cmake
       run: |
-        cmake -B build-cmake -GNinja -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=FALSE
-        cmake --build build-cmake -j
-        ctest --test-dir build-cmake -j
-        mkdir build-cmake/drop
-        bash ./tools/dump_build_env.sh c++ build-cmake/drop/env-info.json
+        cmake --preset default -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=FALSE
+        cmake --build --preset default -j
+        ctest --preset default -j
+        mkdir build/cmake/drop
+        bash ./tools/dump_build_env.sh c++ build/cmake/drop/env-info.json
+
+    - name: Build and run freestanding test with AppleClang on cmake
+      run: |
+        cmake --preset freestanding -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=FALSE
+        cmake --build --preset freestanding -j
+        ctest --preset freestanding -j
 
     - name: Build and run test with AppleClang on meson
       run: |
-        meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
-        meson test -C build-meson
-        meson test -C build-meson --benchmark --test-args=--benchmark_list_tests=true
+        meson setup build/meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
+        meson test -C build/meson
+        meson test -C build/meson --benchmark --test-args=--benchmark_list_tests=true
+
+    - name: Build and run freestanding test with AppleClang on meson
+      run: |
+        meson setup build/meson-freestanding --buildtype=release -Dfreestanding=true
+        meson test -C build/meson-freestanding
 
     - name: Build and Run test with AppleClang on bazel
       run: bazel test --lockfile_mode=error //tests:proxy_tests //benchmarks:proxy_benchmarks //docs/...
 
     - name: Run benchmarks
-      run: build-cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build-cmake/drop/benchmarking-results.json
+      run: build/cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
 
     - name: Archive benchmarking results
       uses: actions/upload-artifact@v7
       with:
         name: drop-appleclang
-        path: build-cmake/drop/
+        path: build/cmake/drop/

--- a/.github/workflows/bvt-clang.yml
+++ b/.github/workflows/bvt-clang.yml
@@ -34,26 +34,40 @@ jobs:
 
     - name: Build and run test with clang ${{ env.CLANG_VERSION }} on cmake
       run: |
-        cmake -B build-cmake -GNinja -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=TRUE
-        cmake --build build-cmake -j
-        ctest --test-dir build-cmake -j
-        mkdir build-cmake/drop
-        bash ./tools/dump_build_env.sh "$CXX" build-cmake/drop/env-info.json
+        cmake --preset default -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE
+        cmake --build --preset default -j
+        ctest --preset default -j
+        mkdir build/cmake/drop
+        bash ./tools/dump_build_env.sh "$CXX" build/cmake/drop/env-info.json
+
+    - name: Build and run freestanding test with clang ${{ env.CLANG_VERSION }} on cmake
+      run: |
+        cmake --preset freestanding -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE
+        cmake --build --preset freestanding -j
+        ctest --preset freestanding -j
 
     - name: Build and run test with clang ${{ env.CLANG_VERSION }} on meson
       run: |
-        meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
-        meson test -C build-meson
-        meson test -C build-meson --benchmark --test-args=--benchmark_list_tests=true
+        meson setup build/meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
+        meson test -C build/meson
+        meson test -C build/meson --benchmark --test-args=--benchmark_list_tests=true
+
+    - name: Build and run freestanding test with clang ${{ env.CLANG_VERSION }} on meson
+      run: |
+        meson setup build/meson-freestanding --buildtype=release -Dfreestanding=true
+        meson test -C build/meson-freestanding
 
     - name: Build and Run test with clang ${{ env.CLANG_VERSION }} on bazel
-      run: bazel test --lockfile_mode=error //tests:proxy_tests //tests:proxy_freestanding_tests //benchmarks:proxy_benchmarks //docs/...
+      run: bazel test --lockfile_mode=error //tests:proxy_tests //benchmarks:proxy_benchmarks //docs/...
+
+    - name: Build and run freestanding test with clang ${{ env.CLANG_VERSION }} on bazel
+      run: bazel test --config=freestanding --lockfile_mode=error //tests:proxy_freestanding_tests
 
     - name: Run benchmarks
-      run: build-cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build-cmake/drop/benchmarking-results.json
+      run: build/cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
 
     - name: Archive benchmarking results
       uses: actions/upload-artifact@v7
       with:
         name: drop-clang
-        path: build-cmake/drop/
+        path: build/cmake/drop/

--- a/.github/workflows/bvt-compatibility.yml
+++ b/.github/workflows/bvt-compatibility.yml
@@ -11,7 +11,7 @@ jobs:
       matrix:
         compiler:
           - {family: gcc, version: 13, modules: false, doc_tests: true}
-          - {family: gcc, version: 14, modules: true, doc_tests: true}
+          - {family: gcc, version: 14, modules: false, doc_tests: true}
           - {family: clang, version: 16, modules: false, doc_tests: false}
           - {family: clang, version: 17, modules: false, doc_tests: true}
           - {family: clang, version: 18, modules: false, doc_tests: true}

--- a/.github/workflows/bvt-compatibility.yml
+++ b/.github/workflows/bvt-compatibility.yml
@@ -53,6 +53,12 @@ jobs:
 
     - name: Build and run test with cmake
       run: |
-        cmake -B build -GNinja -DCMAKE_BUILD_TYPE=Release '-DPROXY_BUILD_MODULES=${{ matrix.compiler.modules }}' '-DBUILD_DOC_TESTING=${{ matrix.compiler.doc_tests }}'
-        cmake --build build -j
-        ctest --test-dir build -j
+        cmake --preset default '-DPROXY_BUILD_MODULES=${{ matrix.compiler.modules }}' '-DBUILD_DOC_TESTING=${{ matrix.compiler.doc_tests }}'
+        cmake --build --preset default -j
+        ctest --preset default -j
+
+    - name: Build and run freestanding test with cmake
+      run: |
+        cmake --preset freestanding '-DPROXY_BUILD_MODULES=${{ matrix.compiler.modules }}' '-DBUILD_DOC_TESTING=${{ matrix.compiler.doc_tests }}'
+        cmake --build --preset freestanding -j
+        ctest --preset freestanding -j

--- a/.github/workflows/bvt-gcc.yml
+++ b/.github/workflows/bvt-gcc.yml
@@ -27,27 +27,41 @@ jobs:
 
     - name: Build and run test with gcc 15 on cmake
       run: |
-        cmake -B build-cmake -GNinja -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=TRUE
-        cmake --build build-cmake -j
-        ctest --test-dir build-cmake -j
-        mkdir build-cmake/drop
+        cmake --preset default -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE
+        cmake --build --preset default -j
+        ctest --preset default -j
+        mkdir build/cmake/drop
         chmod +x tools/dump_build_env.sh
-        ./tools/dump_build_env.sh g++ build-cmake/drop/env-info.json
+        ./tools/dump_build_env.sh g++ build/cmake/drop/env-info.json
+
+    - name: Build and run freestanding test with gcc 15 on cmake
+      run: |
+        cmake --preset freestanding -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE
+        cmake --build --preset freestanding -j
+        ctest --preset freestanding -j
 
     - name: Build and run test with gcc 15 on meson
       run: |
-        meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
-        meson test -C build-meson
-        meson test -C build-meson --benchmark --test-args=--benchmark_list_tests=true
+        meson setup build/meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
+        meson test -C build/meson
+        meson test -C build/meson --benchmark --test-args=--benchmark_list_tests=true
+
+    - name: Build and run freestanding test with gcc 15 on meson
+      run: |
+        meson setup build/meson-freestanding --buildtype=release -Dfreestanding=true
+        meson test -C build/meson-freestanding
 
     - name: Build and Run test with gcc 15 on bazel
-      run: bazel test --lockfile_mode=error //tests:proxy_tests //tests:proxy_freestanding_tests //benchmarks:proxy_benchmarks //docs/...
+      run: bazel test --lockfile_mode=error //tests:proxy_tests //benchmarks:proxy_benchmarks //docs/...
+
+    - name: Build and run freestanding test with gcc 15 on bazel
+      run: bazel test --config=freestanding --lockfile_mode=error //tests:proxy_freestanding_tests
 
     - name: Run benchmarks
-      run: build-cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build-cmake/drop/benchmarking-results.json
+      run: build/cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
 
     - name: Archive benchmarking results
       uses: actions/upload-artifact@v7
       with:
         name: drop-gcc
-        path: build-cmake/drop/
+        path: build/cmake/drop/

--- a/.github/workflows/bvt-msvc.yml
+++ b/.github/workflows/bvt-msvc.yml
@@ -22,26 +22,26 @@ jobs:
 
     - name: Build and run test with MSVC on cmake
       run: |
-        cmake -B build-cmake -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE `
-          && cmake --build build-cmake --config Release -j `
-          && ctest --test-dir build-cmake -C Release -j `
-          && mkdir build-cmake\drop > $null `
-          && .\tools\dump_build_env_msvc.ps1 -OutputPath build-cmake\drop\env-info.json
+        cmake -B build/cmake -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE `
+          && cmake --build build/cmake --config Release -j `
+          && ctest --test-dir build/cmake -C Release -j `
+          && mkdir build/cmake/drop > $null `
+          && .\tools\dump_build_env_msvc.ps1 -OutputPath build/cmake/drop/env-info.json
 
     - name: Build and run test with MSVC on meson
       run: |
-        meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled --vsenv
-        meson test -C build-meson
-        meson test -C build-meson --benchmark --test-args=--benchmark_list_tests=true
+        meson setup build/meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled --vsenv
+        meson test -C build/meson
+        meson test -C build/meson --benchmark --test-args=--benchmark_list_tests=true
 
     - name: Build and Run test with MSVC on bazel
       run: bazel test --lockfile_mode=error //tests:proxy_tests //benchmarks:proxy_benchmarks //docs/...
 
     - name: Run benchmarks
-      run: build-cmake\benchmarks\Release\msft_proxy_benchmarks.exe --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build-cmake\drop\benchmarking-results.json
+      run: build/cmake/benchmarks/Release/msft_proxy_benchmarks.exe --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
 
     - name: Archive benchmarking results
       uses: actions/upload-artifact@v7
       with:
         name: drop-msvc
-        path: build-cmake/drop/
+        path: build/cmake/drop/

--- a/.github/workflows/bvt-nvhpc.yml
+++ b/.github/workflows/bvt-nvhpc.yml
@@ -37,24 +37,24 @@ jobs:
 
     - name: Build and run test with NVHPC ${{ env.NVHPC_VERSION }} on cmake
       run: |
-        cmake -B build-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DPROXY_BUILD_MODULES=FALSE
-        cmake --build build-cmake -j
-        ctest --test-dir build-cmake -j
-        mkdir build-cmake/drop
+        cmake --preset default -DPROXY_BUILD_MODULES=FALSE
+        cmake --build --preset default -j
+        ctest --preset default -j
+        mkdir build/cmake/drop
         chmod +x tools/dump_build_env.sh
-        ./tools/dump_build_env.sh "$CXX" build-cmake/drop/env-info.json
+        ./tools/dump_build_env.sh "$CXX" build/cmake/drop/env-info.json
 
     - name: Build and run test with NVHPC ${{ env.NVHPC_VERSION }} on meson
       run: |
-        meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
-        meson test -C build-meson
-        meson test -C build-meson --benchmark --test-args=--benchmark_list_tests=true
+        meson setup build/meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
+        meson test -C build/meson
+        meson test -C build/meson --benchmark --test-args=--benchmark_list_tests=true
 
     - name: Run benchmarks
-      run: build-cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build-cmake/drop/benchmarking-results.json
+      run: build/cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
 
     - name: Archive benchmarking results
       uses: actions/upload-artifact@v7
       with:
         name: drop-nvhpc
-        path: build-cmake/drop/
+        path: build/cmake/drop/

--- a/.github/workflows/bvt-oneapi.yml
+++ b/.github/workflows/bvt-oneapi.yml
@@ -42,26 +42,40 @@ jobs:
 
     - name: Build and run test with oneapi on cmake
       run: |
-        cmake -B build-cmake -GNinja -DCMAKE_CXX_STANDARD=23 -DCMAKE_BUILD_TYPE=Release
-        cmake --build build-cmake -j
-        ctest --test-dir build-cmake -j
-        mkdir build-cmake/drop
-        bash ./tools/dump_build_env.sh "$CXX" build-cmake/drop/env-info.json
+        cmake --preset default -DCMAKE_CXX_STANDARD=23
+        cmake --build --preset default -j
+        ctest --preset default -j
+        mkdir build/cmake/drop
+        bash ./tools/dump_build_env.sh "$CXX" build/cmake/drop/env-info.json
+
+    - name: Build and run freestanding test with oneapi on cmake
+      run: |
+        cmake --preset freestanding -DCMAKE_CXX_STANDARD=23
+        cmake --build --preset freestanding -j
+        ctest --preset freestanding -j
 
     - name: Build and run test with oneapi on meson
       run: |
-        meson setup build-meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
-        meson test -C build-meson
-        meson test -C build-meson --benchmark --test-args=--benchmark_list_tests=true
+        meson setup build/meson --buildtype=release -Dtests=enabled -Dbenchmarks=enabled
+        meson test -C build/meson
+        meson test -C build/meson --benchmark --test-args=--benchmark_list_tests=true
+
+    - name: Build and run freestanding test with oneapi on meson
+      run: |
+        meson setup build/meson-freestanding --buildtype=release -Dfreestanding=true
+        meson test -C build/meson-freestanding
 
     - name: Build and Run test with oneapi on bazel
-      run: bazel test --lockfile_mode=error --cxxopt=-Wno-c++23-extensions --test_env=LD_LIBRARY_PATH //tests:proxy_tests //tests:proxy_freestanding_tests //benchmarks:proxy_benchmarks //docs/...
+      run: bazel test --lockfile_mode=error --cxxopt=-Wno-c++23-extensions --test_env=LD_LIBRARY_PATH //tests:proxy_tests //benchmarks:proxy_benchmarks //docs/...
+
+    - name: Build and run freestanding test with oneapi on bazel
+      run: bazel test --config=freestanding --lockfile_mode=error --cxxopt=-Wno-c++23-extensions --test_env=LD_LIBRARY_PATH //tests:proxy_freestanding_tests
 
     - name: Run benchmarks
-      run: build-cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build-cmake/drop/benchmarking-results.json
+      run: build/cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
 
     - name: Archive benchmarking results
       uses: actions/upload-artifact@v7
       with:
         name: drop-oneapi
-        path: build-cmake/drop/
+        path: build/cmake/drop/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,16 @@ if(PROJECT_IS_TOP_LEVEL)
     "When this project is top level, build the docs and tests with C++ module support."
     OFF
   )
+  option(
+    PROXY_FREESTANDING
+    "When this project is top level, configure proxy and its tests for a freestanding environment. GCC/Clang only."
+    OFF
+  )
+endif()
+
+if(PROXY_FREESTANDING)
+  add_compile_options(-ffreestanding -fno-exceptions -fno-rtti)
+  add_link_options(-nodefaultlibs -lc)
 endif()
 
 file(GLOB_RECURSE proxy_public_headers CONFIGURE_DEPENDS
@@ -101,24 +111,6 @@ install(
 if(BUILD_TESTING)
   include(CTest)
 
-  include(cmake/read_dependencies.cmake)
-  proxy_read_dependencies("${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.json")
-
-  include(FetchContent)
-  # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
-  # allows for proper rebuilds when a projects URL changes.
-  if(POLICY CMP0135)
-    cmake_policy(SET CMP0135 NEW)
-  endif()
-
-  FetchContent_Declare(
-    fmt
-    URL ${PROXY_FMT_URL}
-    URL_HASH SHA256=${PROXY_FMT_SHA256}
-    SYSTEM
-  )
-  FetchContent_MakeAvailable(fmt)
-
   if(MSVC)
     set(PROXY_BUILD_FLAGS /utf-8 /W4)
     set(PROXY_STRICT_WARNING_FLAGS ${PROXY_BUILD_FLAGS} /WX)
@@ -133,10 +125,32 @@ if(BUILD_TESTING)
     set(PROXY_STRICT_WARNING_FLAGS ${PROXY_BUILD_FLAGS} -Werror)
   endif()
 
-  add_subdirectory(tests)
-  add_subdirectory(benchmarks)
+  if(PROXY_FREESTANDING)
+    add_subdirectory(tests/freestanding)
+  else()
+    include(cmake/read_dependencies.cmake)
+    proxy_read_dependencies("${CMAKE_CURRENT_SOURCE_DIR}/cmake/dependencies.json")
 
-  if(BUILD_DOC_TESTING)
-    add_subdirectory(docs)
+    include(FetchContent)
+    # The policy uses the download time for timestamp, instead of the timestamp in the archive. This
+    # allows for proper rebuilds when a projects URL changes.
+    if(POLICY CMP0135)
+      cmake_policy(SET CMP0135 NEW)
+    endif()
+
+    FetchContent_Declare(
+      fmt
+      URL ${PROXY_FMT_URL}
+      URL_HASH SHA256=${PROXY_FMT_SHA256}
+      SYSTEM
+    )
+    FetchContent_MakeAvailable(fmt)
+
+    add_subdirectory(tests)
+    add_subdirectory(benchmarks)
+
+    if(BUILD_DOC_TESTING)
+      add_subdirectory(docs)
+    endif()
   endif()
 endif()

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -1,0 +1,55 @@
+{
+  "version": 3,
+  "cmakeMinimumRequired": {
+    "major": 3,
+    "minor": 28,
+    "patch": 0
+  },
+  "configurePresets": [
+    {
+      "name": "default",
+      "displayName": "Default hosted build",
+      "generator": "Ninja",
+      "binaryDir": "${sourceDir}/build/cmake",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Release",
+        "CMAKE_CXX_STANDARD": "20"
+      }
+    },
+    {
+      "name": "freestanding",
+      "displayName": "Freestanding build",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build/cmake-freestanding",
+      "cacheVariables": {
+        "PROXY_FREESTANDING": "ON"
+      }
+    }
+  ],
+  "buildPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default"
+    },
+    {
+      "name": "freestanding",
+      "configurePreset": "freestanding"
+    }
+  ],
+  "testPresets": [
+    {
+      "name": "default",
+      "configurePreset": "default",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "freestanding",
+      "configurePreset": "freestanding",
+      "output": {
+        "outputOnFailure": true
+      }
+    }
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -316,9 +316,9 @@ Then drive the tests through any of the supported build systems:
 ### CMake
 
 ```
-cmake -B build
-cmake --build build -j
-ctest --test-dir build -j
+cmake --preset default
+cmake --build --preset default -j
+ctest --preset default -j
 ```
 
 ### Meson

--- a/include/proxy/v4/proxy.ixx
+++ b/include/proxy/v4/proxy.ixx
@@ -6,9 +6,17 @@ export module proxy.v4;
 
 export namespace pro::inline v4 {
 
+#if __STDC_HOSTED__
 using v4::allocate_proxy;
 using v4::allocate_proxy_shared;
+using v4::make_proxy;
+using v4::make_proxy_shared;
+#endif // __STDC_HOSTED__
+
+#if __cpp_rtti >= 199711L
 using v4::bad_proxy_cast;
+#endif // __cpp_rtti >= 199711L
+
 using v4::basic_facade_builder;
 using v4::constraint_level;
 using v4::conversion_dispatch;
@@ -20,9 +28,7 @@ using v4::implicit_conversion_dispatch;
 using v4::inplace_proxiable_target;
 using v4::is_bitwise_trivially_relocatable;
 using v4::is_bitwise_trivially_relocatable_v;
-using v4::make_proxy;
 using v4::make_proxy_inplace;
-using v4::make_proxy_shared;
 using v4::make_proxy_view;
 using v4::not_implemented;
 using v4::observer_facade;

--- a/meson.build
+++ b/meson.build
@@ -32,6 +32,21 @@ elif cxx.get_id() == 'nvidia_hpc'
   )
 endif
 
+freestanding = get_option('freestanding')
+if freestanding
+  add_project_arguments(
+    '-ffreestanding',
+    '-fno-exceptions',
+    '-fno-rtti',
+    language: 'cpp',
+  )
+  add_project_link_arguments(
+    '-nodefaultlibs',
+    '-lc',
+    language: 'cpp',
+  )
+endif
+
 inc = include_directories('include')
 
 msft_proxy4_dep = declare_dependency(
@@ -57,36 +72,41 @@ endif
 meson.override_dependency(meson.project_name(), msft_proxy4_dep)
 
 tests = get_option('tests').disable_auto_if(meson.is_subproject())
-gtest_dep = dependency(
-  'gtest_main',
-  main: true,
-  required: tests,
-  default_options: ['warning_level=0'],
-)
-fmt_dep = dependency(
-  'fmt',
-  version: '>=6.1.0',
-  required: tests,
-  disabler: true,
-  default_options: ['warning_level=0'],
-  include_type: 'system',
-)
-subdir(
-  'tests',
-  if_found: gtest_dep,
-)
 
-benchmarks = get_option('benchmarks').disable_auto_if(meson.is_subproject())
-benchmark_dep = dependency(
-  'benchmark_main',
-  required: benchmarks,
-  default_options: ['warning_level=0'],
-)
-subdir(
-  'benchmarks',
-  if_found: benchmark_dep,
-)
+if freestanding
+  subdir('tests/freestanding')
+else
+  gtest_dep = dependency(
+    'gtest_main',
+    main: true,
+    required: tests,
+    default_options: ['warning_level=0'],
+  )
+  fmt_dep = dependency(
+    'fmt',
+    version: '>=6.1.0',
+    required: tests,
+    disabler: true,
+    default_options: ['warning_level=0'],
+    include_type: 'system',
+  )
+  subdir(
+    'tests',
+    if_found: gtest_dep,
+  )
 
-if tests.allowed() and get_option('doc_tests')
-  subdir('docs')
+  benchmarks = get_option('benchmarks').disable_auto_if(meson.is_subproject())
+  benchmark_dep = dependency(
+    'benchmark_main',
+    required: benchmarks,
+    default_options: ['warning_level=0'],
+  )
+  subdir(
+    'benchmarks',
+    if_found: benchmark_dep,
+  )
+
+  if tests.allowed() and get_option('doc_tests')
+    subdir('docs')
+  endif
 endif

--- a/meson.options
+++ b/meson.options
@@ -16,3 +16,9 @@ option(
   value: true,
   description: 'Build and run tests extracted from docs (requires tests)',
 )
+option(
+  'freestanding',
+  type: 'boolean',
+  value: false,
+  description: 'Configure proxy and its tests for a freestanding environment.',
+)

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -41,15 +41,7 @@ cc_test(
 cc_test(
     name = "proxy_freestanding_tests",
     srcs = ["freestanding/proxy_freestanding_tests.cpp"],
-    copts = PROXY_STRICT_BUILD_COPTS + [
-        "-ffreestanding",
-        "-fno-exceptions",
-        "-fno-rtti",
-    ],
-    linkopts = [
-        "-nodefaultlibs",
-        "-lc",
-    ],
+    copts = PROXY_STRICT_BUILD_COPTS,
     target_compatible_with = ["@platforms//os:linux"],
     deps = ["//:proxy"],
 )

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,28 +35,4 @@ target_link_libraries(
 target_compile_options(msft_proxy_tests PRIVATE ${PROXY_STRICT_WARNING_FLAGS})
 gtest_discover_tests(msft_proxy_tests)
 
-if(
-  CMAKE_CXX_COMPILER_ID STREQUAL "GNU"
-  OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang"
-)
-  add_executable(
-    msft_proxy_freestanding_tests
-    freestanding/proxy_freestanding_tests.cpp
-  )
-  target_compile_options(
-    msft_proxy_freestanding_tests
-    PRIVATE
-      -ffreestanding
-      -fno-exceptions
-      -fno-rtti
-      ${PROXY_STRICT_WARNING_FLAGS}
-  )
-  target_link_options(msft_proxy_freestanding_tests PRIVATE -nodefaultlibs -lc)
-  target_link_libraries(
-    msft_proxy_freestanding_tests
-    PRIVATE msft_proxy4::proxy
-  )
-  add_test(NAME ProxyFreestandingTests COMMAND msft_proxy_freestanding_tests)
-endif()
-
 add_subdirectory(modules)

--- a/tests/freestanding/CMakeLists.txt
+++ b/tests/freestanding/CMakeLists.txt
@@ -1,0 +1,26 @@
+add_executable(msft_proxy_freestanding_tests proxy_freestanding_tests.cpp)
+target_compile_options(
+  msft_proxy_freestanding_tests
+  PRIVATE ${PROXY_STRICT_WARNING_FLAGS}
+)
+target_link_libraries(msft_proxy_freestanding_tests PRIVATE msft_proxy4::proxy)
+add_test(NAME ProxyFreestandingTests COMMAND msft_proxy_freestanding_tests)
+
+if(PROXY_BUILD_MODULES)
+  add_executable(
+    msft_proxy_freestanding_module_tests
+    proxy_freestanding_module_tests.cpp
+  )
+  target_compile_options(
+    msft_proxy_freestanding_module_tests
+    PRIVATE ${PROXY_STRICT_WARNING_FLAGS}
+  )
+  target_link_libraries(
+    msft_proxy_freestanding_module_tests
+    PRIVATE msft_proxy4::proxy_module
+  )
+  add_test(
+    NAME ProxyFreestandingModuleSupportTests
+    COMMAND msft_proxy_freestanding_module_tests
+  )
+endif()

--- a/tests/freestanding/meson.build
+++ b/tests/freestanding/meson.build
@@ -1,0 +1,13 @@
+test(
+  'ProxyFreestandingTests',
+  executable(
+    'msft_proxy_freestanding_tests',
+    files('proxy_freestanding_tests.cpp'),
+    implicit_include_directories: false,
+    dependencies: msft_proxy4_dep,
+    override_options: {
+      'werror': true,
+    },
+    build_by_default: false,
+  ),
+)

--- a/tests/freestanding/proxy_freestanding_module_tests.cpp
+++ b/tests/freestanding/proxy_freestanding_module_tests.cpp
@@ -1,0 +1,52 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#if __STDC_HOSTED__
+#error "This file shall be compiled targeting a freestanding environment."
+#endif // __STDC_HOSTED__
+
+#include <proxy/proxy_macros.h>
+
+#include <new>
+#include <type_traits>
+#include <utility>
+
+import proxy.v4;
+
+constexpr unsigned DefaultHash = -1;
+unsigned GetHashImpl(int v) { return static_cast<unsigned>(v + 3) * 31; }
+unsigned GetHashImpl(double v) { return static_cast<unsigned>(v * v + 5) * 87; }
+unsigned GetHashImpl(const char* v) {
+  unsigned result = 91u;
+  for (int i = 0; v[i]; ++i) {
+    result = result * 47u + v[i];
+  }
+  return result;
+}
+unsigned GetHashImpl(auto&&) { return DefaultHash; }
+PRO_DEF_FREE_DISPATCH(FreeGetHash, GetHashImpl, GetHash);
+
+struct Hashable : pro::facade_builder                       //
+                  ::add_convention<FreeGetHash, unsigned()> //
+                  ::build {};
+
+extern "C" int main() {
+  int i = 123;
+  double d = 3.14159;
+  const char* s = "lalala";
+  pro::proxy<Hashable> p;
+  p = &i;
+  if (GetHash(*p) != GetHashImpl(i)) {
+    return 1;
+  }
+  p = &d;
+  if (GetHash(*p) != GetHashImpl(d)) {
+    return 1;
+  }
+  p = pro::make_proxy_inplace<Hashable>(s);
+  if (GetHash(*p) != GetHashImpl(s)) {
+    return 1;
+  }
+  return 0;
+}

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -37,37 +37,3 @@ test(
   ),
   protocol: 'gtest',
 )
-
-freestanding_cflags = ['-ffreestanding']
-freestanding_ldflags = ['-nodefaultlibs']
-
-if cxx.has_multi_arguments(
-  freestanding_cflags,
-  freestanding_ldflags,
-  required: false,
-)
-  libc_dep = cxx.find_library(
-    'c',
-    required: false,
-  )
-
-  if libc_dep.found()
-    test(
-      'ProxyFreestandingSupportTests',
-      executable(
-        'msft_proxy_freestanding_tests',
-        files('freestanding/proxy_freestanding_tests.cpp'),
-        implicit_include_directories: false,
-        dependencies: [msft_proxy4_dep, libc_dep],
-        cpp_args: freestanding_cflags,
-        link_args: get_option('b_sanitize') == 'none' ? freestanding_ldflags : [],
-        override_options: {
-          'cpp_eh': 'none',
-          'cpp_rtti': false,
-          'werror': true,
-        },
-        build_by_default: false,
-      ),
-    )
-  endif
-endif


### PR DESCRIPTION
**Changes**

- Added freestanding guards to `proxy.ixx`.
- Added a freestanding-modules test case, and hooked with the 3 build systems.
- Disabled modules tests for GCC 14 (compatibility) because freestanding tests won't pass (see [the failed CI build](https://github.com/ngcpp/proxy/actions/runs/27866566761))

Resolves #20