### PR TITLE
Suppress unreachable code warning from MSVC

### DIFF
--- a/include/proxy/v4/detail/core.h
+++ b/include/proxy/v4/detail/core.h
@@ -823,6 +823,13 @@ operand_t<P, IsDirect, Q> get_operand(proxy_accessor<F, IsDirect, Q> p) {
     return *std::forward<add_qualifier_t<P, Q>>(ptr);
   }
 }
+
+// When a dispatch always throws, MSVC may incorrectly warn about unreachable
+// code (C4702). Disable the warning for invoke_dispatch().
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(push)
+#pragma warning(disable : 4702)
+#endif // defined(_MSC_VER) && !defined(__clang__)
 template <class D, class R, class... Args>
 R invoke_dispatch(Args&&... args) {
   if constexpr (std::is_void_v<R>) {
@@ -831,6 +838,9 @@ R invoke_dispatch(Args&&... args) {
     return D()(std::forward<Args>(args)...);
   }
 }
+#if defined(_MSC_VER) && !defined(__clang__)
+#pragma warning(pop)
+#endif // defined(_MSC_VER) && !defined(__clang__)
 template <class P, class F, bool IsDirect, qualifier_type Q, class D, class R,
           class... Args>
 R reinterpret_invoke(proxy_accessor<F, IsDirect, Q> self, Args&&... args) {

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -14,15 +14,7 @@
 #include <typeindex>
 #include <typeinfo>
 #include <vector>
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(                                                               \
-    disable : 4702) // False alarm from MSVC: warning C4702: unreachable code
-#endif              // defined(_MSC_VER) && !defined(__clang__)
 #include <proxy/proxy.h>
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif // defined(_MSC_VER) && !defined(__clang__)
 #include "utils.h"
 
 namespace proxy_invocation_tests_detail {

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -14,7 +14,9 @@
 #include <typeindex>
 #include <typeinfo>
 #include <vector>
+
 #include <proxy/proxy.h>
+
 #include "utils.h"
 
 namespace proxy_invocation_tests_detail {

--- a/tests/proxy_regression_tests.cpp
+++ b/tests/proxy_regression_tests.cpp
@@ -3,15 +3,7 @@
 // Licensed under the MIT License.
 
 #include <gtest/gtest.h>
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(push)
-#pragma warning(                                                               \
-    disable : 4702) // False alarm from MSVC: warning C4702: unreachable code
-#endif              // defined(_MSC_VER) && !defined(__clang__)
 #include <proxy/proxy.h>
-#if defined(_MSC_VER) && !defined(__clang__)
-#pragma warning(pop)
-#endif // defined(_MSC_VER) && !defined(__clang__)
 #include <vector>
 
 namespace proxy_regression_tests_detail {


### PR DESCRIPTION
Moved unreachable code warning suppression from unit tests to the library implementation. The unit tests pattern is innocent.