### PR TITLE
Add the code coverage job

### DIFF
--- a/.github/workflows/bvt-codecoverage.yml
+++ b/.github/workflows/bvt-codecoverage.yml
@@ -1,0 +1,53 @@
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  bvt-codecoverage:
+    runs-on: ubuntu-24.04
+    container: gcc:16
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Install CMake, Ninja, and gcovr
+      run: |
+        apt-get update
+        apt-get install -y cmake ninja-build gcovr
+
+    - name: Check toolchain versions
+      run: |
+        g++ --version
+        gcov --version
+        cmake --version
+        ninja --version
+        gcovr --version
+
+    - name: Build and run tests with code coverage instrumentation
+      run: |
+        cmake --preset coverage -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE
+        cmake --build --preset coverage -j
+        ctest --preset coverage -j
+
+    - name: Build and run freestanding tests with code coverage instrumentation
+      run: |
+        cmake --preset coverage-freestanding -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=TRUE
+        cmake --build --preset coverage-freestanding -j
+        ctest --preset coverage-freestanding -j
+
+    - name: Generate code coverage report
+      run: |
+        mkdir -p build/coverage/report
+        gcovr --root . \
+          --filter 'include/proxy/' \
+          --gcov-executable gcov \
+          --exclude-unreachable-branches \
+          --print-summary \
+          --txt build/coverage/report/coverage.txt \
+          --xml-pretty --output build/coverage/report/coverage.xml \
+          --html-details build/coverage/report/coverage.html
+
+    - name: Upload code coverage report
+      uses: actions/upload-artifact@v7
+      with:
+        name: coverage-report
+        path: build/coverage/report/

--- a/.github/workflows/bvt-codecoverage.yml
+++ b/.github/workflows/bvt-codecoverage.yml
@@ -12,8 +12,7 @@ jobs:
     - name: Install CMake, Ninja, and gcovr
       run: |
         apt-get update
-        apt-get install -y cmake ninja-build python3-pip
-        pip install --break-system-packages gcovr
+        apt-get install -y cmake ninja-build gcovr
 
     - name: Check toolchain versions
       run: |
@@ -46,14 +45,16 @@ jobs:
           --txt build/coverage/report/coverage.txt \
           --xml-pretty --output build/coverage/report/coverage.xml \
           --html-details build/coverage/report/coverage.html \
-          --markdown-summary build/coverage/report/coverage.md \
-          build/coverage build/coverage-freestanding
+          build/coverage build/coverage-freestanding \
+          | tee build/coverage/report/summary.txt
 
     - name: Publish coverage summary
       run: |
         {
           echo "## Code coverage"
-          cat build/coverage/report/coverage.md
+          echo '```'
+          cat build/coverage/report/summary.txt
+          echo '```'
         } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload code coverage report

--- a/.github/workflows/bvt-codecoverage.yml
+++ b/.github/workflows/bvt-codecoverage.yml
@@ -12,7 +12,8 @@ jobs:
     - name: Install CMake, Ninja, and gcovr
       run: |
         apt-get update
-        apt-get install -y cmake ninja-build gcovr
+        apt-get install -y cmake ninja-build python3-pip
+        pip install --break-system-packages gcovr
 
     - name: Check toolchain versions
       run: |
@@ -44,7 +45,16 @@ jobs:
           --print-summary \
           --txt build/coverage/report/coverage.txt \
           --xml-pretty --output build/coverage/report/coverage.xml \
-          --html-details build/coverage/report/coverage.html
+          --html-details build/coverage/report/coverage.html \
+          --markdown-summary build/coverage/report/coverage.md \
+          build/coverage build/coverage-freestanding
+
+    - name: Publish coverage summary
+      run: |
+        {
+          echo "## Code coverage"
+          cat build/coverage/report/coverage.md
+        } >> "$GITHUB_STEP_SUMMARY"
 
     - name: Upload code coverage report
       uses: actions/upload-artifact@v7

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -48,6 +48,11 @@ jobs:
     name: Run BVT for compatibility
     if: github.event_name != 'push' || github.repository == 'ngcpp/proxy'
 
+  run-bvt-codecoverage:
+    uses: ./.github/workflows/bvt-codecoverage.yml
+    name: Run BVT for code coverage
+    if: github.event_name != 'push' || github.repository == 'ngcpp/proxy'
+
   report:
     uses: ./.github/workflows/bvt-report.yml
     name: Generate report

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,8 +32,8 @@
       "binaryDir": "${sourceDir}/build/coverage",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS": "--coverage -O0 -g",
-        "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+        "CMAKE_CXX_FLAGS_DEBUG": "--coverage",
+        "CMAKE_EXE_LINKER_FLAGS_DEBUG": "--coverage"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -32,8 +32,8 @@
       "binaryDir": "${sourceDir}/build/coverage",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug",
-        "CMAKE_CXX_FLAGS_DEBUG": "--coverage",
-        "CMAKE_EXE_LINKER_FLAGS_DEBUG": "--coverage"
+        "CMAKE_CXX_FLAGS": "--coverage -O0 -g",
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage"
       }
     },
     {

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -24,6 +24,26 @@
       "cacheVariables": {
         "PROXY_FREESTANDING": "ON"
       }
+    },
+    {
+      "name": "coverage",
+      "displayName": "Code coverage build",
+      "inherits": "default",
+      "binaryDir": "${sourceDir}/build/coverage",
+      "cacheVariables": {
+        "CMAKE_BUILD_TYPE": "Debug",
+        "CMAKE_CXX_FLAGS": "--coverage -O0 -g",
+        "CMAKE_EXE_LINKER_FLAGS": "--coverage"
+      }
+    },
+    {
+      "name": "coverage-freestanding",
+      "displayName": "Code coverage freestanding build",
+      "inherits": "coverage",
+      "binaryDir": "${sourceDir}/build/coverage-freestanding",
+      "cacheVariables": {
+        "PROXY_FREESTANDING": "ON"
+      }
     }
   ],
   "buildPresets": [
@@ -34,6 +54,14 @@
     {
       "name": "freestanding",
       "configurePreset": "freestanding"
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage"
+    },
+    {
+      "name": "coverage-freestanding",
+      "configurePreset": "coverage-freestanding"
     }
   ],
   "testPresets": [
@@ -47,6 +75,20 @@
     {
       "name": "freestanding",
       "configurePreset": "freestanding",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "coverage",
+      "configurePreset": "coverage",
+      "output": {
+        "outputOnFailure": true
+      }
+    },
+    {
+      "name": "coverage-freestanding",
+      "configurePreset": "coverage-freestanding",
       "output": {
         "outputOnFailure": true
       }


### PR DESCRIPTION
## What
Adds a dedicated code coverage job to the CI pipeline. It builds the tests with GCC coverage instrumentation, runs  both the hosted and freestanding test suites, generates a coverage report scoped to the public headers  (`include/proxy/`), publishes a summary to the workflow run page, and uploads the full report as an artifact.

## Samples
```
lines: 99.0% (483 out of 488)
functions: 24.6% (7784 out of 31594)
branches: 76.3% (100 out of 131)
```

<img width="691" height="95" alt="image" src="https://github.com/user-attachments/assets/1ce06dd1-1df7-4220-8fe0-44a25d875dc2" />
