### PR TITLE
Relax reflection constraints

### DIFF
--- a/docs/spec/ProBasicReflection.md
+++ b/docs/spec/ProBasicReflection.md
@@ -7,7 +7,7 @@ A type `R` meets the *ProBasicReflection* requirements if the following expressi
 | Expressions                  | Semantics                                                    |
 | ---------------------------- | ------------------------------------------------------------ |
 | `R::is_direct`               | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) of type `bool`, specifying whether the reflection applies to a pointer type itself (`true`), or the element type of a pointer type (`false`). |
-| `typename R::reflector_type` | A type that defines the data structure reflected from the type. Shall be *nothrow-default-constructible* and *nothrow-destructible*. |
+| `typename R::reflector_type` | A type that defines the data structure reflected from the type. |
 
 ## See Also
 

--- a/docs/spec/ProReflection.md
+++ b/docs/spec/ProReflection.md
@@ -6,7 +6,7 @@ A type `R` meets the *ProReflection* requirements of a type `P` if `R` meets the
 
 | Expressions                                         | Semantics                                                    |
 | --------------------------------------------------- | ------------------------------------------------------------ |
-| `typename R::reflector_type(std::in_place_type<T>)` | A [core constant expression](https://en.cppreference.com/w/cpp/language/constant_expression) that constructs a value of type `typename R::reflector_type`, reflecting implementation-defined metadata of type `T`. |
+| `typename R::reflector_type(std::in_place_type<T>)` | Constructs a value of type `typename R::reflector_type`, reflecting implementation-defined metadata of type `T`. |
 
 ## See Also
 

--- a/include/proxy/v4/detail/core.h
+++ b/include/proxy/v4/detail/core.h
@@ -470,9 +470,7 @@ template <class T, bool IsDirect, class R>
 consteval bool is_reflector_well_formed() {
   if constexpr (IsDirect) {
     if constexpr (std::is_constructible_v<R, std::in_place_type_t<T>>) {
-      if constexpr (is_consteval([] { return R(std::in_place_type<T>); })) {
-        return true;
-      }
+      return true;
     }
   } else {
     return is_reflector_well_formed<
@@ -745,7 +743,7 @@ struct meta_ptr_indirect_impl {
 private:
   const M* ptr_;
   template <class P>
-  static constexpr M storage{std::in_place_type<P>};
+  static inline const M storage{std::in_place_type<P>};
 };
 template <class M, class DM>
 struct meta_ptr_direct_impl : private M {

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -274,7 +274,7 @@ struct RuntimeReflection {
 struct FacadeWithRuntimeReflection : pro::facade_builder                 //
                                      ::add_reflection<RuntimeReflection> //
                                      ::build {};
-static_assert(!pro::proxiable<MockTrivialPtr, FacadeWithRuntimeReflection>);
+static_assert(pro::proxiable<MockTrivialPtr, FacadeWithRuntimeReflection>);
 
 struct FacadeWithTupleLikeConventions {
   struct ToStringConvention {


### PR DESCRIPTION
Indirect metadata storage, which includes any reflection, does not necessarily be `constexpr` or *nothrow-default-constructible*. This change allows reflections happen at runtime. For existing `constexpr` reflections, this change does not affect their code gen.

Updated tests and spec accordingly.