### PR TITLE
Pointer authentication (PAC) for clang

### DIFF
--- a/.github/workflows/bvt-appleclang-arm64e.yml
+++ b/.github/workflows/bvt-appleclang-arm64e.yml
@@ -1,0 +1,39 @@
+on:
+  workflow_call:
+  workflow_dispatch:
+
+jobs:
+  bvt-appleclang-arm64e:
+    runs-on: macos-26
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Check toolchain versions
+      run: |
+        cc --version
+        xcodebuild -version
+        cmake --version
+        ninja --version
+
+    - name: Build and run test with AppleClang (arm64e with PAC) on cmake
+      run: |
+        cmake --preset default -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=FALSE -DCMAKE_OSX_ARCHITECTURES=arm64e
+        cmake --build --preset default -j
+        ctest --preset default -j
+        mkdir build/cmake/drop
+        bash ./tools/dump_build_env.sh c++ build/cmake/drop/env-info.json
+
+    - name: Build and run freestanding test with AppleClang (arm64e with PAC) on cmake
+      run: |
+        cmake --preset freestanding -DCMAKE_CXX_STANDARD=23 -DPROXY_BUILD_MODULES=FALSE -DCMAKE_OSX_ARCHITECTURES=arm64e
+        cmake --build --preset freestanding -j
+        ctest --preset freestanding -j
+
+    - name: Run benchmarks
+      run: build/cmake/benchmarks/msft_proxy_benchmarks --benchmark_min_warmup_time=0.1 --benchmark_min_time=0.1s --benchmark_repetitions=30 --benchmark_enable_random_interleaving=true --benchmark_report_aggregates_only=true --benchmark_format=json > build/cmake/drop/benchmarking-results.json
+
+    - name: Archive benchmarking results
+      uses: actions/upload-artifact@v7
+      with:
+        name: drop-apple-pac
+        path: build/cmake/drop/

--- a/.github/workflows/pipeline-ci.yml
+++ b/.github/workflows/pipeline-ci.yml
@@ -33,6 +33,10 @@ jobs:
     name: Run BVT with AppleClang
     if: github.event_name != 'push' || github.repository == 'ngcpp/proxy'
 
+  run-bvt-appleclang-arm64e:
+    uses: ./.github/workflows/bvt-appleclang-arm64e.yml
+    name: Run BVT with AppleClang (arm64e with PAC)
+
   run-bvt-nvhpc:
     uses: ./.github/workflows/bvt-nvhpc.yml
     name: Run BVT with NVHPC
@@ -56,4 +60,4 @@ jobs:
   report:
     uses: ./.github/workflows/bvt-report.yml
     name: Generate report
-    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-nvhpc, run-bvt-oneapi]
+    needs: [run-bvt-gcc, run-bvt-clang, run-bvt-msvc, run-bvt-appleclang, run-bvt-appleclang-arm64e, run-bvt-nvhpc, run-bvt-oneapi]

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Ignore build directories
-build/
+/build*
 Testing/
 
 # Python bytecode cache

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,7 +120,7 @@ if(BUILD_TESTING)
       -Wall
       -Wextra
       -Wpedantic
-      $<$<CXX_COMPILER_ID:Clang>:-Wno-c++2b-extensions>
+      $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-c++2b-extensions>
     )
     set(PROXY_STRICT_WARNING_FLAGS ${PROXY_BUILD_FLAGS} -Werror)
   endif()

--- a/docs/spec/basic_facade_builder/build.md
+++ b/docs/spec/basic_facade_builder/build.md
@@ -59,10 +59,8 @@ int main() {
   static_assert(std::is_nothrow_move_constructible_v<pro::proxy<CopyableBase>>);
   static_assert(std::is_nothrow_destructible_v<pro::proxy<CopyableBase>>);
 
-  static_assert(
-      std::is_trivially_copy_constructible_v<pro::proxy<TrivialBase>>);
-  static_assert(
-      std::is_trivially_move_constructible_v<pro::proxy<TrivialBase>>);
+  static_assert(std::is_nothrow_copy_constructible_v<pro::proxy<TrivialBase>>);
+  static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialBase>>);
   static_assert(std::is_trivially_destructible_v<pro::proxy<TrivialBase>>);
 }
 ```

--- a/include/proxy/v4/detail/compatibility_check.h
+++ b/include/proxy/v4/detail/compatibility_check.h
@@ -25,4 +25,12 @@ static_assert(sizeof(derived) == sizeof(char),
 } // namespace pro::inline v4::detail::compatibility_check
 #endif
 
+#ifdef __has_feature
+#if __has_feature(ptrauth_calls) &&                                            \
+    (!defined(__PTRAUTH__) || !__has_include(<ptrauth.h>))
+#error "The Pointer Authentication feature is incomplete"
+#endif // __has_feature(ptrauth_calls) && (!defined(__PTRAUTH__) ||
+       // !__has_include(<ptrauth.h>))
+#endif // __has_feature
+
 #endif // MSFT_PROXY_V4_DETAIL_COMPATIBILITY_CHECK_H_

--- a/include/proxy/v4/detail/core.h
+++ b/include/proxy/v4/detail/core.h
@@ -17,6 +17,7 @@
 #include <utility>
 
 #include "../proxy_macros.h"
+#include "./facade_meta_traits.h"
 
 #if __has_cpp_attribute(msvc::no_unique_address)
 #define PRO4D_NO_UNIQUE_ADDRESS_ATTRIBUTE msvc::no_unique_address
@@ -38,6 +39,9 @@ namespace detail {
 
 template <class F>
 struct basic_facade_traits;
+
+template <class F>
+struct meta_storage;
 
 } // namespace detail
 
@@ -232,14 +236,15 @@ struct proxy_helper {
     proxy<F>& p_;
   };
 
-  template <class M, class F>
-  static const M& get_meta(const proxy<F>& p) noexcept {
+  template <class F>
+  static const meta_storage<F>& get_meta(const proxy<F>& p) noexcept {
     assert(p.has_value());
-    return static_cast<const M&>(*p.meta_.operator->());
+    return p.meta_;
   }
-  template <class M, class F>
-  static const M& get_meta(const proxy_indirect_accessor<F>& p) noexcept {
-    return get_meta<M>(as_proxy<F, qualifier_type::const_lv>(p));
+  template <class F>
+  static const meta_storage<F>&
+      get_meta(const proxy_indirect_accessor<F>& p) noexcept {
+    return get_meta(as_proxy<F, qualifier_type::const_lv>(p));
   }
   template <class P, class F, qualifier_type Q>
   static add_qualifier_t<P, Q> get_ptr(add_qualifier_t<proxy<F>, Q> p) {
@@ -348,32 +353,6 @@ consteval void diagnose_proxiable_required_convention_not_implemented() {
                 "not proxiable due to a required convention not implemented");
 }
 
-template <class ProP, class D, class O>
-struct conv_meta;
-#define PRO4D_DEF_CONV_META(oq, pq, ne, ...)                                   \
-  template <class ProP, class D, class R, class... Args>                       \
-  struct conv_meta<ProP, D, R(Args...) oq ne> {                                \
-    conv_meta() = default;                                                     \
-    template <class P>                                                         \
-    constexpr explicit conv_meta(std::in_place_type_t<P>)                      \
-        : invoke([](ProP pq self, Args... args) ne -> R {                      \
-            return reinterpret_invoke<P, D, R>(static_cast<ProP pq>(self),     \
-                                               std::forward<Args>(args)...);   \
-          }) {}                                                                \
-                                                                               \
-    R (*invoke)(ProP pq, Args...) ne;                                          \
-  }
-PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(PRO4D_DEF_CONV_META)
-#undef PRO4D_DEF_CONV_META
-
-template <class... Ms>
-struct PRO4D_ENFORCE_EBO composite_meta : Ms... {
-  composite_meta() = default;
-  template <class P>
-  constexpr explicit composite_meta(std::in_place_type_t<P>)
-      : Ms(std::in_place_type<P>)... {}
-};
-
 template <class T>
 consteval bool is_is_direct_well_formed() {
   if constexpr (requires {
@@ -422,7 +401,7 @@ template <class C, class F, class... Os>
 struct conv_traits_impl {
   static_assert((overload_traits<substituted_overload_t<Os, F>>::applicable &&
                  ...));
-  using meta = composite_meta<conv_meta<
+  using meta = std::tuple<invoker<
       std::conditional_t<C::is_direct, proxy<F>, proxy_indirect_accessor<F>>,
       typename C::dispatch_type, substituted_overload_t<Os, F>>...>;
   template <class T>
@@ -513,10 +492,10 @@ template <class F, class D, class ONE, class OE, constraint_level C>
 struct lifetime_meta_traits : std::type_identity<void> {};
 template <class F, class D, class ONE, class OE>
 struct lifetime_meta_traits<F, D, ONE, OE, constraint_level::nothrow>
-    : std::type_identity<conv_meta<proxy<F>, D, ONE>> {};
+    : std::type_identity<invoker<proxy<F>, D, ONE>> {};
 template <class F, class D, class ONE, class OE>
 struct lifetime_meta_traits<F, D, ONE, OE, constraint_level::nontrivial>
-    : std::type_identity<conv_meta<proxy<F>, D, OE>> {};
+    : std::type_identity<invoker<proxy<F>, D, OE>> {};
 template <class F, class D, class ONE, class OE, constraint_level C>
 using lifetime_meta_t = typename lifetime_meta_traits<F, D, ONE, OE, C>::type;
 
@@ -648,7 +627,7 @@ struct basic_facade_traits<F> : applicable_traits {};
 template <class F, class... Cs>
 struct facade_conv_traits_impl {
   using conv_meta =
-      composite_t<composite_meta<>, typename conv_traits<Cs, F>::meta...>;
+      composite_t<std::tuple<>, typename conv_traits<Cs, F>::meta...>;
   using conv_indirect_accessor =
       composite_t<composite_accessor<>, conv_accessor_t<Cs, F, false>...>;
   using conv_direct_accessor =
@@ -665,7 +644,7 @@ struct facade_conv_traits_impl {
 };
 template <class F, class... Rs>
 struct facade_refl_traits_impl {
-  using refl_meta = composite_meta<
+  using refl_meta = std::tuple<
       reflection_meta<Rs::is_direct, typename Rs::reflector_type>...>;
   using refl_indirect_accessor =
       composite_t<composite_accessor<>, refl_accessor_t<Rs, F, false>...>;
@@ -690,15 +669,18 @@ struct facade_traits : specialization_t<facade_conv_traits_impl,
                                         typename F::convention_types, F>,
                        specialization_t<facade_refl_traits_impl,
                                         typename F::reflection_types, F> {
-  using meta = composite_t<
-      composite_meta<>,
-      lifetime_meta_t<F, copy_dispatch, void(proxy<F>&) const noexcept,
-                      void(proxy<F>&) const, F::copyability>,
-      lifetime_meta_t<F, relocate_dispatch, void(proxy<F>&) && noexcept,
-                      void(proxy<F>&) &&, F::relocatability>,
-      lifetime_meta_t<F, destroy_dispatch, void() noexcept, void(),
-                      F::destructibility>,
-      typename facade_traits::conv_meta, typename facade_traits::refl_meta>;
+  using meta_storage_base = specialization_t<
+      compact_facade_meta_traits::storage,
+      composite_t<
+          std::tuple<>,
+          lifetime_meta_t<F, copy_dispatch, void(proxy<F>&) const noexcept,
+                          void(proxy<F>&) const, F::copyability>,
+          lifetime_meta_t<F, relocate_dispatch, void(proxy<F>&) && noexcept,
+                          void(proxy<F>&) &&, F::relocatability>,
+          lifetime_meta_t<F, destroy_dispatch, void() noexcept, void(),
+                          F::destructibility>,
+          typename facade_traits::conv_meta,
+          typename facade_traits::refl_meta>>;
   using indirect_accessor =
       composite_t<typename facade_traits::conv_indirect_accessor,
                   typename facade_traits::refl_indirect_accessor>;
@@ -728,47 +710,11 @@ struct facade_traits : specialization_t<facade_conv_traits_impl,
       facade_traits::template refl_applicable_ptr<P>;
 };
 
-using ptr_prototype = void* [2];
-
-template <class M>
-struct meta_ptr_indirect_impl {
-  meta_ptr_indirect_impl() = default;
-  template <class P>
-  explicit meta_ptr_indirect_impl(std::in_place_type_t<P>)
-      : ptr_(&storage<P>) {}
-  bool has_value() const noexcept { return ptr_ != nullptr; }
-  void reset() noexcept { ptr_ = nullptr; }
-  const M* operator->() const noexcept { return ptr_; }
-
-private:
-  const M* ptr_;
-  template <class P>
-  static inline const M storage{std::in_place_type<P>};
+template <class F>
+struct meta_storage : facade_traits<F>::meta_storage_base {
+  using base = typename facade_traits<F>::meta_storage_base;
+  using base::base;
 };
-template <class M, class DM>
-struct meta_ptr_direct_impl : private M {
-  using M::M;
-  bool has_value() const noexcept { return this->DM::invoke != nullptr; }
-  void reset() noexcept { this->DM::invoke = nullptr; }
-  const M* operator->() const noexcept { return this; }
-};
-template <class M>
-struct meta_ptr_traits_impl : std::type_identity<meta_ptr_indirect_impl<M>> {};
-template <class ProP, class D, class O, class... Ms>
-struct meta_ptr_traits_impl<composite_meta<conv_meta<ProP, D, O>, Ms...>>
-    : std::type_identity<
-          meta_ptr_direct_impl<composite_meta<conv_meta<ProP, D, O>, Ms...>,
-                               conv_meta<ProP, D, O>>> {};
-template <class M>
-struct meta_ptr_traits : std::type_identity<meta_ptr_indirect_impl<M>> {};
-template <class M>
-  requires(sizeof(M) <= sizeof(ptr_prototype) &&
-           alignof(M) <= alignof(ptr_prototype) &&
-           std::is_nothrow_default_constructible_v<M> &&
-           std::is_trivially_copyable_v<M>)
-struct meta_ptr_traits<M> : meta_ptr_traits_impl<M> {};
-template <class M>
-using meta_ptr = typename meta_ptr_traits<M>::type;
 
 template <class T>
 class inplace_ptr {
@@ -796,8 +742,9 @@ private:
 
 template <class D, class O, class P, class... Args>
 ret_t<O> invoke_impl(P&& p, Args&&... args) {
-  return proxy_helper::get_meta<conv_meta<std::remove_cvref_t<P>, D, O>>(p)
-      .invoke(std::forward<P>(p), std::forward<Args>(args)...);
+  return proxy_helper::get_meta(p)
+      .template get<invoker<std::remove_cvref_t<P>, D, O>>()(
+          std::forward<P>(p), std::forward<Args>(args)...);
 }
 template <class F, qualifier_type Q>
 add_qualifier_t<proxy<F>, Q>
@@ -921,7 +868,8 @@ public:
   }
   template <class R>
   friend const R& reflect(const proxy_indirect_accessor& p) noexcept {
-    return detail::proxy_helper::get_meta<detail::reflection_meta<false, R>>(p)
+    return detail::proxy_helper::get_meta(p)
+        .template get<detail::reflection_meta<false, R>>()
         .reflector;
   }
 };
@@ -1159,7 +1107,8 @@ public:
   }
   template <class R>
   friend const R& reflect(const proxy& p) noexcept {
-    return detail::proxy_helper::get_meta<detail::reflection_meta<true, R>>(p)
+    return detail::proxy_helper::get_meta(p)
+        .template get<detail::reflection_meta<true, R>>()
         .reflector;
   }
 
@@ -1210,8 +1159,7 @@ private:
     P& result = *std::construct_at(reinterpret_cast<P*>(ptr_),
                                    std::forward<Args>(args)...);
     if constexpr (proxiable<P, F>) {
-      meta_ = detail::meta_ptr<typename detail::facade_traits<F>::meta>{
-          std::in_place_type<P>};
+      meta_ = detail::meta_storage<F>{std::in_place_type<P>};
     } else {
       detail::facade_traits<F>::template diagnose_proxiable_noreturn<P>();
     }
@@ -1238,7 +1186,7 @@ private:
     *std::move(cself);
   })
 
-  detail::meta_ptr<typename detail::facade_traits<F>::meta> meta_;
+  detail::meta_storage<F> meta_;
   alignas(F::max_align) std::byte ptr_[F::max_size];
 };
 

--- a/include/proxy/v4/detail/core.h
+++ b/include/proxy/v4/detail/core.h
@@ -712,7 +712,7 @@ struct facade_traits : specialization_t<facade_conv_traits_impl,
 
 template <class F>
 struct meta_storage : facade_traits<F>::meta_storage_base {
-  using base = typename facade_traits<F>::meta_storage_base;
+  using base = facade_traits<F>::meta_storage_base;
   using base::base;
 };
 

--- a/include/proxy/v4/detail/facade_creation.h
+++ b/include/proxy/v4/detail/facade_creation.h
@@ -29,6 +29,8 @@ consteval std::size_t max_align_of(std::size_t value) {
   return value < alignof(std::max_align_t) ? value : alignof(std::max_align_t);
 }
 
+using ptr_prototype = void* [2];
+
 template <class T, class U>
 using merge_tuple_t = specialization_t<add_tuple_t, U, T>;
 template <class C1, class C2>

--- a/include/proxy/v4/detail/facade_meta_traits.h
+++ b/include/proxy/v4/detail/facade_meta_traits.h
@@ -163,7 +163,6 @@ struct PRO4D_ENFORCE_EBO inline_meta_storage : First, Rest... {
   constexpr explicit inline_meta_storage(std::in_place_type_t<P>)
       : First(std::in_place_type<P>), Rest(std::in_place_type<P>)... {}
   inline_meta_storage(const inline_meta_storage& rhs) noexcept
-    requires(sizeof...(Rest) > 0u)
       : inline_meta_storage() {
     if (static_cast<const First&>(rhs).has_value()) {
       static_cast<First&>(*this) = static_cast<const First&>(rhs);
@@ -172,12 +171,7 @@ struct PRO4D_ENFORCE_EBO inline_meta_storage : First, Rest... {
       static_cast<First&>(*this).reset();
     }
   }
-  inline_meta_storage(const inline_meta_storage&)
-    requires(sizeof...(Rest) == 0u)
-  = default;
-  inline_meta_storage& operator=(const inline_meta_storage& rhs) noexcept
-    requires(sizeof...(Rest) > 0u)
-  {
+  inline_meta_storage& operator=(const inline_meta_storage& rhs) noexcept {
     if (static_cast<const First&>(rhs).has_value()) {
       static_cast<First&>(*this) = static_cast<const First&>(rhs);
       ((static_cast<Rest&>(*this) = static_cast<const Rest&>(rhs)), ...);
@@ -186,9 +180,15 @@ struct PRO4D_ENFORCE_EBO inline_meta_storage : First, Rest... {
     }
     return *this;
   }
-  inline_meta_storage& operator=(const inline_meta_storage&)
-    requires(sizeof...(Rest) == 0u)
-  = default;
+  template <class M>
+  const M& get() const noexcept {
+    return static_cast<const M&>(*this);
+  }
+};
+template <nullable First>
+struct inline_meta_storage<First> : First {
+  using First::First;
+
   template <class M>
   const M& get() const noexcept {
     return static_cast<const M&>(*this);

--- a/include/proxy/v4/detail/facade_meta_traits.h
+++ b/include/proxy/v4/detail/facade_meta_traits.h
@@ -1,0 +1,255 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#ifndef MSFT_PROXY_V4_DETAIL_FACADE_META_TRAITS_H_
+#define MSFT_PROXY_V4_DETAIL_FACADE_META_TRAITS_H_
+
+#include <cstddef>
+#include <type_traits>
+#include <utility>
+
+#ifdef __has_feature
+#if __has_feature(ptrauth_calls)
+#include <ptrauth.h>
+#define PRO4D_HAS_PAC
+#endif // __has_feature(ptrauth_calls)
+#endif // __has_feature
+
+#include "../proxy_macros.h"
+
+namespace pro::inline v4 {
+
+namespace detail {
+
+#ifdef PRO4D_HAS_PAC
+template <class O, class Disc>
+class code_ptr {
+public:
+  code_ptr() = default;
+  template <class F>
+  explicit code_ptr(const F& f) noexcept
+      : p_(ptrauth_sign_unauthenticated(
+            ptrauth_strip(static_cast<O*>(f), ptrauth_key_function_pointer),
+            ptrauth_key_function_pointer, schema())) {}
+  code_ptr(const code_ptr& rhs) noexcept
+      : p_(ptrauth_auth_and_resign(rhs.p_, ptrauth_key_function_pointer,
+                                   rhs.schema(), ptrauth_key_function_pointer,
+                                   schema())) {}
+  code_ptr& operator=(const code_ptr& rhs) noexcept {
+    p_ = ptrauth_auth_and_resign(rhs.p_, ptrauth_key_function_pointer,
+                                 rhs.schema(), ptrauth_key_function_pointer,
+                                 schema());
+    return *this;
+  }
+  code_ptr& operator=(std::nullptr_t) noexcept {
+    p_ = nullptr;
+    return *this;
+  }
+  bool operator==(std::nullptr_t) const noexcept { return p_ == nullptr; }
+  template <class... Args>
+  decltype(auto) operator()(Args&&... args) const {
+    return ptrauth_auth_function(p_, ptrauth_key_function_pointer,
+                                 schema())(std::forward<Args>(args)...);
+  }
+
+private:
+  ptrauth_extra_data_t schema() const noexcept {
+    return ptrauth_blend_discriminator(&p_, ptrauth_type_discriminator(Disc));
+  }
+
+  O* p_;
+};
+
+template <class T, class Disc>
+class meta_ptr {
+public:
+  meta_ptr() = default;
+  explicit meta_ptr(const T* p) noexcept
+      : p_(ptrauth_sign_unauthenticated(p, ptrauth_key_cxx_vtable_pointer,
+                                        schema())) {}
+  meta_ptr(const meta_ptr& rhs) noexcept
+      : p_(ptrauth_auth_and_resign(rhs.p_, ptrauth_key_cxx_vtable_pointer,
+                                   rhs.schema(), ptrauth_key_cxx_vtable_pointer,
+                                   schema())) {}
+  meta_ptr& operator=(const meta_ptr& rhs) noexcept {
+    p_ = ptrauth_auth_and_resign(rhs.p_, ptrauth_key_cxx_vtable_pointer,
+                                 rhs.schema(), ptrauth_key_cxx_vtable_pointer,
+                                 schema());
+    return *this;
+  }
+  meta_ptr& operator=(std::nullptr_t) noexcept {
+    p_ = nullptr;
+    return *this;
+  }
+  bool operator==(std::nullptr_t) const noexcept { return p_ == nullptr; }
+  const T& operator*() const noexcept {
+    return *ptrauth_auth_data(p_, ptrauth_key_cxx_vtable_pointer, schema());
+  }
+
+private:
+  ptrauth_extra_data_t schema() const noexcept {
+    return ptrauth_blend_discriminator(&p_, ptrauth_type_discriminator(Disc));
+  }
+
+  const T* p_;
+};
+#else
+template <class O, class Disc>
+using code_ptr = O*;
+
+template <class T, class Disc>
+using meta_ptr = const T*;
+#endif // PRO4D_HAS_PAC
+
+template <class T>
+concept nullable = requires(T v, const T cv) {
+  { v.reset() } noexcept;
+  { cv.has_value() } noexcept -> std::same_as<bool>;
+};
+
+template <class O, class Disc>
+struct invoker_base {
+  invoker_base() = default;
+  template <class F>
+  constexpr explicit invoker_base(const F& f) : p_(f) {}
+  void reset() noexcept { p_ = nullptr; }
+  bool has_value() const noexcept { return p_ != nullptr; }
+  template <class... Args>
+  decltype(auto) operator()(Args&&... args) const {
+    return p_(std::forward<Args>(args)...);
+  }
+
+private:
+  code_ptr<O, Disc> p_;
+};
+
+template <class ProP, class D, class O>
+struct invoker;
+#define PRO4D_DEF_INVOKER(oq, pq, ne, ...)                                     \
+  template <class ProP, class D, class R, class... Args>                       \
+  struct invoker<ProP, D, R(Args...) oq ne>                                    \
+      : invoker_base<R(ProP pq, Args...) ne, R (*)(ProP pq, D, Args...) ne> {  \
+    invoker() = default;                                                       \
+    template <class P>                                                         \
+    constexpr explicit invoker(std::in_place_type_t<P>)                        \
+        : invoker_base<R(ProP pq, Args...) ne, R (*)(ProP pq, D, Args...) ne>( \
+              [](ProP pq self, Args... args) ne -> R {                         \
+                return reinterpret_invoke<P, D, R>(                            \
+                    static_cast<ProP pq>(self), std::forward<Args>(args)...);  \
+              }) {}                                                            \
+  }
+PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(PRO4D_DEF_INVOKER)
+#undef PRO4D_DEF_INVOKER
+
+struct sentinel_meta {
+  sentinel_meta() = default;
+  template <class P>
+  explicit sentinel_meta(std::in_place_type_t<P>) noexcept : v_(1) {}
+  void reset() noexcept { v_ = 0; }
+  bool has_value() const noexcept { return v_; }
+
+private:
+  std::ptrdiff_t v_;
+};
+
+template <nullable First, class... Rest>
+struct PRO4D_ENFORCE_EBO inline_meta_storage : First, Rest... {
+  using First::has_value;
+  using First::reset;
+
+  constexpr inline_meta_storage() noexcept {}
+  template <class P>
+  constexpr explicit inline_meta_storage(std::in_place_type_t<P>)
+      : First(std::in_place_type<P>), Rest(std::in_place_type<P>)... {}
+  inline_meta_storage(const inline_meta_storage& rhs) noexcept
+    requires(sizeof...(Rest) > 0u)
+      : inline_meta_storage() {
+    if (static_cast<const First&>(rhs).has_value()) {
+      static_cast<First&>(*this) = static_cast<const First&>(rhs);
+      ((static_cast<Rest&>(*this) = static_cast<const Rest&>(rhs)), ...);
+    } else {
+      static_cast<First&>(*this).reset();
+    }
+  }
+  inline_meta_storage(const inline_meta_storage&)
+    requires(sizeof...(Rest) == 0u)
+  = default;
+  inline_meta_storage& operator=(const inline_meta_storage& rhs) noexcept
+    requires(sizeof...(Rest) > 0u)
+  {
+    if (static_cast<const First&>(rhs).has_value()) {
+      static_cast<First&>(*this) = static_cast<const First&>(rhs);
+      ((static_cast<Rest&>(*this) = static_cast<const Rest&>(rhs)), ...);
+    } else {
+      static_cast<First&>(*this).reset();
+    }
+    return *this;
+  }
+  inline_meta_storage& operator=(const inline_meta_storage&)
+    requires(sizeof...(Rest) == 0u)
+  = default;
+  template <class M>
+  const M& get() const noexcept {
+    return static_cast<const M&>(*this);
+  }
+};
+
+template <class... Ms>
+struct static_meta_storage {
+  static_meta_storage() = default;
+  template <class P>
+  explicit static_meta_storage(std::in_place_type_t<P>)
+      : ptr_(std::addressof(storage<P>)) {}
+  bool has_value() const noexcept { return ptr_ != nullptr; }
+  void reset() noexcept { ptr_ = nullptr; }
+  template <class M>
+  const M& get() const noexcept {
+    return (*ptr_).template get<M>();
+  }
+
+private:
+  meta_ptr<inline_meta_storage<Ms...>, void (*)(Ms...)> ptr_;
+
+  template <class P>
+  static inline const inline_meta_storage<Ms...> storage{std::in_place_type<P>};
+};
+
+template <class... Ms>
+struct compact_meta_storage_traits
+    : std::type_identity<static_meta_storage<Ms...>> {};
+template <nullable M>
+struct compact_meta_storage_traits<M>
+    : std::type_identity<inline_meta_storage<M>> {};
+template <>
+struct compact_meta_storage_traits<>
+    : std::type_identity<inline_meta_storage<sentinel_meta>> {};
+
+template <class... Ms>
+struct flat_meta_storage_traits
+    : std::type_identity<inline_meta_storage<sentinel_meta, Ms...>> {};
+template <nullable M, class... Ms>
+struct flat_meta_storage_traits<M, Ms...>
+    : std::type_identity<inline_meta_storage<M, Ms...>> {};
+
+} // namespace detail
+
+struct compact_facade_meta_traits {
+  template <class ProP, class D, class O>
+  using invoker = detail::invoker<ProP, D, O>;
+
+  template <class... Ms>
+  using storage = typename detail::compact_meta_storage_traits<Ms...>::type;
+};
+
+struct flat_facade_meta_traits {
+  template <class ProP, class D, class O>
+  using invoker = detail::invoker<ProP, D, O>;
+
+  template <class... Ms>
+  using storage = typename detail::flat_meta_storage_traits<Ms...>::type;
+};
+
+} // namespace pro::inline v4
+
+#endif // MSFT_PROXY_V4_DETAIL_FACADE_META_TRAITS_H_

--- a/include/proxy/v4/detail/facade_meta_traits.h
+++ b/include/proxy/v4/detail/facade_meta_traits.h
@@ -239,7 +239,7 @@ struct compact_facade_meta_traits {
   using invoker = detail::invoker<ProP, D, O>;
 
   template <class... Ms>
-  using storage = typename detail::compact_meta_storage_traits<Ms...>::type;
+  using storage = detail::compact_meta_storage_traits<Ms...>::type;
 };
 
 struct flat_facade_meta_traits {
@@ -247,7 +247,7 @@ struct flat_facade_meta_traits {
   using invoker = detail::invoker<ProP, D, O>;
 
   template <class... Ms>
-  using storage = typename detail::flat_meta_storage_traits<Ms...>::type;
+  using storage = detail::flat_meta_storage_traits<Ms...>::type;
 };
 
 } // namespace pro::inline v4

--- a/tests/BUILD.bazel
+++ b/tests/BUILD.bazel
@@ -23,6 +23,7 @@ cc_test(
         "proxy_integration_tests.cpp",
         "proxy_invocation_tests.cpp",
         "proxy_lifetime_tests.cpp",
+        "proxy_pac_tests.cpp",
         "proxy_reflection_tests.cpp",
         "proxy_regression_tests.cpp",
         "proxy_rtti_tests.cpp",

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -21,6 +21,7 @@ add_executable(
   proxy_integration_tests.cpp
   proxy_invocation_tests.cpp
   proxy_lifetime_tests.cpp
+  proxy_pac_tests.cpp
   proxy_reflection_tests.cpp
   proxy_regression_tests.cpp
   proxy_rtti_tests.cpp

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -6,6 +6,7 @@ test_srcs = files(
   'proxy_integration_tests.cpp',
   'proxy_invocation_tests.cpp',
   'proxy_lifetime_tests.cpp',
+  'proxy_pac_tests.cpp',
   'proxy_reflection_tests.cpp',
   'proxy_regression_tests.cpp',
   'proxy_rtti_tests.cpp',

--- a/tests/proxy_invocation_tests.cpp
+++ b/tests/proxy_invocation_tests.cpp
@@ -218,9 +218,8 @@ TEST(ProxyInvocationTests, TestMultipleDispatches_Duplicated) {
         ::add_convention<detail::FreeForEach,
                          void(std::function<void(int&)>)> //
         ::build {};
-  static_assert(
-      sizeof(pro::detail::facade_traits<DuplicatedIterable>::meta) ==
-      sizeof(pro::detail::facade_traits<detail::Iterable<int>>::meta));
+  static_assert(sizeof(pro::detail::meta_storage<DuplicatedIterable>) ==
+                sizeof(pro::detail::meta_storage<detail::Iterable<int>>));
   std::list<int> l = {1, 2, 3};
   pro::proxy<DuplicatedIterable> p = &l;
   ASSERT_EQ(Size(*p), std::size_t{3});

--- a/tests/proxy_pac_tests.cpp
+++ b/tests/proxy_pac_tests.cpp
@@ -1,0 +1,129 @@
+// Copyright (c) 2022-2026 Microsoft Corporation.
+// Copyright (c) 2026-Present Next Gen C++ Foundation.
+// Licensed under the MIT License.
+
+#include <proxy/proxy.h>
+
+#ifdef PRO4D_HAS_PAC
+#include <array>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <gtest/gtest.h>
+#include <memory>
+#include <utility>
+
+namespace proxy_pac_tests_detail {
+
+template <pro::facade F>
+constexpr bool IsInlineMetaPreferred = pro::detail::specialization_of<
+    typename pro::detail::facade_traits<F>::meta_storage_base,
+    pro::detail::inline_meta_storage>;
+
+template <class T>
+auto GetRawBytes(const T& v) noexcept {
+  std::array<std::byte, sizeof(T)> result;
+  std::memcpy(result.data(), std::addressof(v), sizeof(T));
+  return result;
+}
+
+template <pro::facade F>
+void CorruptMeta(pro::proxy<F>& p) noexcept {
+  const pro::detail::meta_storage<F>& meta =
+      pro::detail::proxy_helper::get_meta(p);
+  std::byte* target = reinterpret_cast<std::byte*>(
+      const_cast<pro::detail::meta_storage<F>*>(std::addressof(meta)));
+  std::uintptr_t word;
+  std::memcpy(&word, target, sizeof(word));
+  word ^= std::uintptr_t{1} << 54u; // Within the PAC bits for any VA size
+  std::memcpy(target, &word, sizeof(word));
+}
+
+template <pro::facade F>
+void BitwiseCopy(pro::proxy<F>& from, pro::proxy<F>& to) {
+  assert(from.has_value() && !to.has_value());
+  std::memcpy(static_cast<void*>(&to), static_cast<const void*>(&from),
+              sizeof(from));
+}
+
+// No conventions and a nothrow destructor: a single signed destroy invoker
+// lives inline in the proxy.
+struct DefaultFacade : pro::facade_builder::build {};
+static_assert(IsInlineMetaPreferred<DefaultFacade>);
+
+// Non-trivial copyability adds more metas than fit inline, so the proxy stores
+// a signed pointer to out-of-line static meta storage.
+struct CopyableFacade : pro::facade_builder                               //
+                        ::support_copy<pro::constraint_level::nontrivial> //
+                        ::build {};
+static_assert(!IsInlineMetaPreferred<CopyableFacade>);
+
+} // namespace proxy_pac_tests_detail
+
+namespace detail = proxy_pac_tests_detail;
+
+TEST(ProxyPacTests, TestBinaryRepresentation_InlineMetaStorage) {
+  pro::proxy<detail::DefaultFacade> p1 = std::make_shared<int>(123);
+  auto p1_data = detail::GetRawBytes(p1);
+  auto p2 = std::move(p1);
+  auto p2_data = detail::GetRawBytes(p2);
+
+  // Pointer authentication signs the stored metadata with address diversity, so
+  // a genuine relocation re-signs it and the raw bytes of the signed meta
+  // change
+  EXPECT_NE(p1_data, p2_data);
+}
+
+TEST(ProxyPacTests, TestBinaryRepresentation_StaticMetaStorage) {
+  pro::proxy<detail::CopyableFacade> p1 = std::make_shared<int>(123);
+  auto p1_data = detail::GetRawBytes(p1);
+  auto p2 = p1;
+  auto p2_data = detail::GetRawBytes(p2);
+
+  // Both inline metadata and static metadata has pointer authentication
+  EXPECT_NE(p1_data, p2_data);
+}
+
+TEST(ProxyPacTests, TestBitFlipAttack_InlineMetaStorage) {
+  EXPECT_DEATH(
+      {
+        int a = 123;
+        pro::proxy<detail::DefaultFacade> p = &a;
+        detail::CorruptMeta(p);
+      },
+      "");
+}
+
+TEST(ProxyPacTests, TestBitFlipAttack_StaticMetaStorage) {
+  EXPECT_DEATH(
+      {
+        int a = 123;
+        pro::proxy<detail::CopyableFacade> p = &a;
+        detail::CorruptMeta(p);
+      },
+      "");
+}
+
+TEST(ProxyPacTests, TestRelocationAttack_InlineMetaStorage) {
+  EXPECT_DEATH(
+      {
+        int a = 123;
+        pro::proxy<detail::DefaultFacade> p1 = &a;
+        pro::proxy<detail::DefaultFacade> p2;
+        detail::BitwiseCopy(p1, p2);
+      },
+      "");
+}
+
+TEST(ProxyPacTests, TestRelocationAttack_StaticMetaStorage) {
+  EXPECT_DEATH(
+      {
+        int a = 123;
+        pro::proxy<detail::CopyableFacade> p1 = &a;
+        pro::proxy<detail::CopyableFacade> p2;
+        detail::BitwiseCopy(p1, p2);
+      },
+      "");
+}
+#endif // PRO4D_HAS_PAC

--- a/tests/proxy_traits_tests.cpp
+++ b/tests/proxy_traits_tests.cpp
@@ -89,8 +89,7 @@ static_assert(
 static_assert(std::is_nothrow_constructible_v<
               pro::proxy<DefaultFacade>, std::in_place_type_t<MockFunctionPtr>,
               MockFunctionPtr>);
-static_assert(sizeof(pro::proxy<DefaultFacade>) ==
-              3 * sizeof(void*)); // VTABLE should be embeded
+static_assert(sizeof(pro::proxy<DefaultFacade>) == 3 * sizeof(void*));
 
 static_assert(!std::is_copy_constructible_v<pro::proxy<DefaultFacade>>);
 static_assert(!std::is_copy_assignable_v<pro::proxy<DefaultFacade>>);
@@ -170,8 +169,7 @@ static_assert(std::is_nothrow_constructible_v<pro::proxy<CopyableFacade>,
                                               MockFunctionPtr>);
 static_assert(
     std::is_nothrow_assignable_v<pro::proxy<CopyableFacade>, MockFunctionPtr>);
-static_assert(sizeof(pro::proxy<CopyableFacade>) ==
-              4 * sizeof(void*)); // VTABLE should be embeded
+static_assert(sizeof(pro::proxy<CopyableFacade>) == 3 * sizeof(void*));
 
 struct CopyableSmallFacade
     : pro::facade_builder                               //
@@ -203,8 +201,7 @@ static_assert(
     std::is_constructible_v<pro::proxy<CopyableSmallFacade>, MockFunctionPtr>);
 static_assert(
     std::is_assignable_v<pro::proxy<CopyableSmallFacade>, MockFunctionPtr>);
-static_assert(sizeof(pro::proxy<CopyableSmallFacade>) ==
-              3 * sizeof(void*)); // VTABLE should be embeded
+static_assert(sizeof(pro::proxy<CopyableSmallFacade>) == 2 * sizeof(void*));
 
 struct TrivialFacade : pro::facade_builder                                   //
                        ::restrict_layout<sizeof(void*), alignof(void*)>      //
@@ -212,14 +209,19 @@ struct TrivialFacade : pro::facade_builder                                   //
                        ::support_relocation<pro::constraint_level::trivial>  //
                        ::support_destruction<pro::constraint_level::trivial> //
                        ::build {};
+#ifdef PRO4D_HAS_PAC
+static_assert(std::is_nothrow_copy_constructible_v<pro::proxy<TrivialFacade>>);
+static_assert(std::is_nothrow_copy_assignable_v<pro::proxy<TrivialFacade>>);
+static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialFacade>>);
+static_assert(std::is_nothrow_move_assignable_v<pro::proxy<TrivialFacade>>);
+#else
 static_assert(
     std::is_trivially_copy_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_copy_assignable_v<pro::proxy<TrivialFacade>>);
-static_assert(std::is_nothrow_move_constructible_v<pro::proxy<TrivialFacade>>);
 static_assert(
     std::is_trivially_move_constructible_v<pro::proxy<TrivialFacade>>);
-static_assert(std::is_nothrow_move_assignable_v<pro::proxy<TrivialFacade>>);
 static_assert(std::is_trivially_move_assignable_v<pro::proxy<TrivialFacade>>);
+#endif // PRO4D_HAS_PAC
 static_assert(std::is_trivially_destructible_v<pro::proxy<TrivialFacade>>);
 static_assert(!pro::proxiable<MockMovablePtr, TrivialFacade>);
 static_assert(!pro::proxiable<MockCopyablePtr, TrivialFacade>);
@@ -244,9 +246,7 @@ static_assert(std::is_nothrow_constructible_v<pro::proxy<TrivialFacade>,
                                               MockFunctionPtr>);
 static_assert(
     std::is_nothrow_assignable_v<pro::proxy<TrivialFacade>, MockFunctionPtr>);
-static_assert(sizeof(pro::proxy<TrivialFacade>) ==
-              2 * sizeof(void*)); // VTABLE should be eliminated, but a
-                                  // placeholder is required
+static_assert(sizeof(pro::proxy<TrivialFacade>) == 2 * sizeof(void*));
 
 struct ReflectionOfSmallPtr {
   template <class P>

--- a/tests/proxy_view_tests.cpp
+++ b/tests/proxy_view_tests.cpp
@@ -30,14 +30,19 @@ static_assert(
     SupportsToString<decltype(*std::declval<pro::proxy<TestFacade>>())>);
 static_assert(sizeof(pro::proxy<TestFacade>) == 3 * sizeof(void*));
 
+#ifdef PRO4D_HAS_PAC
+static_assert(
+    std::is_nothrow_copy_constructible_v<pro::proxy_view<TestFacade>>);
+#else
 static_assert(
     std::is_trivially_copy_constructible_v<pro::proxy_view<TestFacade>>);
+#endif // PRO4D_HAS_PAC
 static_assert(std::is_trivially_destructible_v<pro::proxy_view<TestFacade>>);
 static_assert(SupportsIntPlusEqual<
               decltype(*std::declval<pro::proxy_view<TestFacade>>())>);
 static_assert(
     SupportsToString<decltype(*std::declval<pro::proxy_view<TestFacade>>())>);
-static_assert(sizeof(pro::proxy_view<TestFacade>) == 3 * sizeof(void*));
+static_assert(sizeof(pro::proxy_view<TestFacade>) == 2 * sizeof(void*));
 
 static_assert(std::is_nothrow_convertible_v<pro::proxy<TestFacade>&,
                                             pro::proxy_view<TestFacade>>);

--- a/tools/report_generator/report-config.json
+++ b/tools/report_generator/report-config.json
@@ -24,6 +24,11 @@
       "BenchmarkingResultsPath": "artifacts/drop-appleclang/benchmarking-results.json"
     },
     {
+      "Description": "AppleClang on macOS (arm64e with PAC)",
+      "InfoPath": "artifacts/drop-apple-pac/env-info.json",
+      "BenchmarkingResultsPath": "artifacts/drop-apple-pac/benchmarking-results.json"
+    },
+    {
       "Description": "NVIDIA HPC on Ubuntu",
       "InfoPath": "artifacts/drop-nvhpc/env-info.json",
       "BenchmarkingResultsPath": "artifacts/drop-nvhpc/benchmarking-results.json"


### PR DESCRIPTION
**NOTE**: This is PR *1 of n* for the upcoming v5 major release, targeting the `feature/v5` branch. Once the feature branch is stable, it will be merged into `main`. This PR introduces critical ABI-breaking changes.

**Changes**

- Added header file `detail/facade_meta_traits.h`, which introduces two new public APIs: `compact_facade_meta_traits` and `flat_facade_meta_traits`. These are metadata policy in v5. Currently only `compact_facade_meta_traits` is used from `core.h`. Later this will become a new dimension of `facade`, and the reference from `core.h` will be removed.
- `detail::invoker`, `detail::inline_meta_storage` and `detail::static_meta_storage` are the implementation types of the meta traits. When PAC is enabled for compiler ABI, they will have the same level of security strength as virtual functions.
- Added unit tests for PAC.
- Added a new pipeline and benchmarking for PAC.

Documentation will be updated separately.

(CI is not triggered for the new feature branch (filed #61). Manual CI: https://github.com/mingxwa/proxy/actions/runs/29681375711)

Resolves #7