### PR TITLE
Refactor lifetime model selection into type traits

### DIFF
--- a/docs/spec/allocate_proxy.md
+++ b/docs/spec/allocate_proxy.md
@@ -8,23 +8,23 @@ The definition of `allocate_proxy` makes use of an exposition-only class templat
 
 ```cpp
 // (1)
+template <facade F, class Alloc, class T>
+proxy<F> allocate_proxy(const Alloc& alloc, T&& value);  // freestanding-deleted
+
+// (2)
 template <facade F, class T, class Alloc, class... Args>
 proxy<F> allocate_proxy(const Alloc& alloc, Args&&... args);  // freestanding-deleted
 
-// (2)
+// (3)
 template <facade F, class T, class Alloc, class U, class... Args>
 proxy<F> allocate_proxy(const Alloc& alloc, std::initializer_list<U> il, Args&&... args);  // freestanding-deleted
-
-// (3)
-template <facade F, class Alloc, class T>
-proxy<F> allocate_proxy(const Alloc& alloc, T&& value);  // freestanding-deleted
 ```
 
-`(1)` Creates a `proxy<F>` object containing a value `p` of type *allocated-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<Args>(args)...`.
+`(1)` Creates a `proxy<F>` object containing a value `p` of type *allocated-ptr&lt;*`std::decay_t<T>`*, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<T>(value)`.
 
-`(2)` Creates a `proxy<F>` object containing a value `p` of type *allocated-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `il, std::forward<Args>(args)...`.
+`(2)` Creates a `proxy<F>` object containing a value `p` of type *allocated-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<Args>(args)...`.
 
-`(3)` Creates a `proxy<F>` object containing a value `p` of type *allocated-ptr&lt;*`std::decay_t<T>`*, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<T>(value)`.
+`(3)` Creates a `proxy<F>` object containing a value `p` of type *allocated-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `il, std::forward<Args>(args)...`.
 
 *Since 3.3.0*: For `(1-3)`, if [`proxiable_target<std::decay_t<T>, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 

--- a/docs/spec/allocate_proxy_shared.md
+++ b/docs/spec/allocate_proxy_shared.md
@@ -9,23 +9,23 @@ The definition of `allocate_proxy_shared` makes use of exposition-only class tem
 
 ```cpp
 // (1)
+template <facade F, class Alloc, class T>
+proxy<F> allocate_proxy_shared(const Alloc& alloc, T&& value);  // freestanding-deleted
+
+// (2)
 template <facade F, class T, class Alloc, class... Args>
 proxy<F> allocate_proxy_shared(const Alloc& alloc, Args&&... args);  // freestanding-deleted
 
-// (2)
+// (3)
 template <facade F, class T, class Alloc, class U, class... Args>
 proxy<F> allocate_proxy_shared(const Alloc& alloc, std::initializer_list<U> il, Args&&... args);  // freestanding-deleted
-
-// (3)
-template <facade F, class Alloc, class T>
-proxy<F> allocate_proxy_shared(const Alloc& alloc, T&& value);  // freestanding-deleted
 ```
 
-`(1)` Creates a `proxy<F>` object containing a value `p` of type *strong-compact-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<Args>(args)...`.
+`(1)` Creates a `proxy<F>` object containing a value `p` of type *strong-compact-ptr&lt;*`std::decay_t<T>`*, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<T>(value)`.
 
-`(2)` Creates a `proxy<F>` object containing a value `p` of type *strong-compact-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `il, std::forward<Args>(args)...`.
+`(2)` Creates a `proxy<F>` object containing a value `p` of type *strong-compact-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<Args>(args)...`.
 
-`(3)` Creates a `proxy<F>` object containing a value `p` of type *strong-compact-ptr&lt;*`std::decay_t<T>`*, Alloc&gt;*, where `*p` is direct-non-list-initialized with `std::forward<T>(value)`.
+`(3)` Creates a `proxy<F>` object containing a value `p` of type *strong-compact-ptr&lt;T, Alloc&gt;*, where `*p` is direct-non-list-initialized with `il, std::forward<Args>(args)...`.
 
 For `(1-3)`, if [`proxiable_target<std::decay_t<T>, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 

--- a/docs/spec/make_proxy.md
+++ b/docs/spec/make_proxy.md
@@ -19,23 +19,23 @@ proxy<F> make-proxy-internal(Args&&... args) {
 
 ```cpp
 // (1)
+template <facade F, class T>
+proxy<F> make_proxy(T&& value);  // freestanding-deleted
+
+// (2)
 template <facade F, class T, class... Args>
 proxy<F> make_proxy(Args&&... args);  // freestanding-deleted
 
-// (2)
+// (3)
 template <facade F, class T, class U, class... Args>
 proxy<F> make_proxy(std::initializer_list<U> il, Args&&... args);  // freestanding-deleted
-
-// (3)
-template <facade F, class T>
-proxy<F> make_proxy(T&& value);  // freestanding-deleted
 ```
 
-`(1)` Equivalent to `return make-proxy-internal<F, T>(std::forward<Args>(args)...)`.
+`(1)` Equivalent to `return make-proxy-internal<F, std::decay_t<T>>(std::forward<T>(value))`.
 
-`(2)` Equivalent to `return make-proxy-internal<F, T>(il, std::forward<Args>(args)...)`.
+`(2)` Equivalent to `return make-proxy-internal<F, T>(std::forward<Args>(args)...)`.
 
-`(3)` Equivalent to `return make-proxy-internal<F, std::decay_t<T>>(std::forward<T>(value))`.
+`(3)` Equivalent to `return make-proxy-internal<F, T>(il, std::forward<Args>(args)...)`.
 
 *Since 3.3.0*: For `(1-3)`, if [`proxiable_target<std::decay_t<T>, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 

--- a/docs/spec/make_proxy_inplace.md
+++ b/docs/spec/make_proxy_inplace.md
@@ -8,30 +8,30 @@ The definition of `make_proxy_inplace` makes use of an exposition-only class tem
 
 ```cpp
 // (1)
+template <facade F, class T>
+proxy<F> make_proxy_inplace(T&& value)
+    noexcept(std::is_nothrow_constructible_v<std::decay_t<T>, T>)
+    requires(std::is_constructible_v<std::decay_t<T>, T>);
+
+// (2)
 template <facade F, class T, class... Args>
 proxy<F> make_proxy_inplace(Args&&... args)
     noexcept(std::is_nothrow_constructible_v<T, Args...>)
     requires(std::is_constructible_v<T, Args...>);
 
-// (2)
+// (3)
 template <facade F, class T, class U, class... Args>
 proxy<F> make_proxy_inplace(std::initializer_list<U> il, Args&&... args)
     noexcept(std::is_nothrow_constructible_v<
         T, std::initializer_list<U>&, Args...>)
     requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>);
-
-// (3)
-template <facade F, class T>
-proxy<F> make_proxy_inplace(T&& value)
-    noexcept(std::is_nothrow_constructible_v<std::decay_t<T>, T>)
-    requires(std::is_constructible_v<std::decay_t<T>, T>);
 ```
 
-`(1)` Creates a `proxy<F>` object containing a value `p` of type *inplace-ptr&lt;T&gt;*, where `*p` is direct-non-list-initialized with `std::forward<Args>(args)...`.
+`(1)` Creates a `proxy<F>` object containing a value `p` of type *inplace-ptr&lt;*`std::decay_t`*&gt;*, where `*p` is direct-non-list-initialized with `std::forward<T>(value)`.
 
-`(2)` Creates a `proxy<F>` object containing a value `p` of type *inplace-ptr&lt;T&gt;*, where `*p` is direct-non-list-initialized with `il, std::forward<Args>(args)...`.
+`(2)` Creates a `proxy<F>` object containing a value `p` of type *inplace-ptr&lt;T&gt;*, where `*p` is direct-non-list-initialized with `std::forward<Args>(args)...`.
 
-`(3)` Creates a `proxy<F>` object containing a value `p` of type *inplace-ptr&lt;*`std::decay_t`*&gt;*, where `*p` is direct-non-list-initialized with `std::forward<T>(value)`.
+`(3)` Creates a `proxy<F>` object containing a value `p` of type *inplace-ptr&lt;T&gt;*, where `*p` is direct-non-list-initialized with `il, std::forward<Args>(args)...`.
 
 *Since 3.3.0*: For `(1-3)`, if [`inplace_proxiable_target<std::decay_t<T>, F>`](inplace_proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 

--- a/docs/spec/make_proxy_shared.md
+++ b/docs/spec/make_proxy_shared.md
@@ -7,23 +7,23 @@
 
 ```cpp
 // (1)
+template <facade F, class T>
+proxy<F> make_proxy_shared(T&& value);  // freestanding-deleted
+
+// (2)
 template <facade F, class T, class... Args>
 proxy<F> make_proxy_shared(Args&&... args);  // freestanding-deleted
 
-// (2)
+// (3)
 template <facade F, class T, class U, class... Args>
 proxy<F> make_proxy_shared(std::initializer_list<U> il, Args&&... args);  // freestanding-deleted
-
-// (3)
-template <facade F, class T>
-proxy<F> make_proxy_shared(T&& value);  // freestanding-deleted
 ```
 
-`(1)` Equivalent to `return allocate_proxy_shared<F, T>(std::allocator<void>{}, std::forward<Args>(args)...)`.
+`(1)` Equivalent to `return allocate_proxy_shared<F, std::decay_t<T>>(std::allocator<void>{}, std::forward<T>(value))`.
 
-`(2)` Equivalent to `return allocate_proxy_shared<F, T>(std::allocator<void>{}, il, std::forward<Args>(args)...)`.
+`(2)` Equivalent to `return allocate_proxy_shared<F, T>(std::allocator<void>{}, std::forward<Args>(args)...)`.
 
-`(3)` Equivalent to `return allocate_proxy_shared<F, std::decay_t<T>>(std::allocator<void>{}, std::forward<T>(value))`.
+`(3)` Equivalent to `return allocate_proxy_shared<F, T>(std::allocator<void>{}, il, std::forward<Args>(args)...)`.
 
 *Since 3.3.0*: For `(1-3)`, if [`proxiable_target<std::decay_t<T>, F>`](proxiable_target.md) is `false`, the program is ill-formed and diagnostic messages are generated.
 

--- a/include/proxy/v4/detail/core.h
+++ b/include/proxy/v4/detail/core.h
@@ -716,8 +716,8 @@ struct meta_storage : facade_traits<F>::meta_storage_base {
 template <class T>
 class inplace_ptr {
 public:
-  template <class... Args>
-  explicit inplace_ptr(std::in_place_t, Args&&... args)
+  template <class Ignore, class... Args>
+  explicit inplace_ptr(const Ignore&, Args&&... args)
       : value_(std::forward<Args>(args)...) {}
   inplace_ptr() = default;
   inplace_ptr(const inplace_ptr&) = default;

--- a/include/proxy/v4/detail/proxy_creation.h
+++ b/include/proxy/v4/detail/proxy_creation.h
@@ -30,6 +30,14 @@ template <class T>
 struct is_bitwise_trivially_relocatable<detail::inplace_ptr<T>>
     : std::true_type {};
 
+template <facade F, class T>
+constexpr proxy<F> make_proxy_inplace(T&& value) noexcept(
+    std::is_nothrow_constructible_v<std::decay_t<T>, T>)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return proxy<F>{std::in_place_type<detail::inplace_ptr<std::decay_t<T>>>,
+                  std::in_place, std::forward<T>(value)};
+}
 template <facade F, class T, class... Args>
 constexpr proxy<F> make_proxy_inplace(Args&&... args) noexcept(
     std::is_nothrow_constructible_v<T, Args...>)
@@ -46,14 +54,6 @@ constexpr proxy<F>
 {
   return proxy<F>{std::in_place_type<detail::inplace_ptr<T>>, std::in_place, il,
                   std::forward<Args>(args)...};
-}
-template <facade F, class T>
-constexpr proxy<F> make_proxy_inplace(T&& value) noexcept(
-    std::is_nothrow_constructible_v<std::decay_t<T>, T>)
-  requires(std::is_constructible_v<std::decay_t<T>, T>)
-{
-  return proxy<F>{std::in_place_type<detail::inplace_ptr<std::decay_t<T>>>,
-                  std::in_place, std::forward<T>(value)};
 }
 
 template <facade F, class T>
@@ -107,21 +107,21 @@ protected:
 };
 
 template <class T, class Alloc>
-class PRO4D_ENFORCE_EBO allocated_ptr : private alloc_aware<Alloc>,
-                                        public indirect_ptr<inplace_ptr<T>> {
+class PRO4D_ENFORCE_EBO wide_ptr : private alloc_aware<Alloc>,
+                                   public indirect_ptr<inplace_ptr<T>> {
 public:
   template <class... Args>
-  allocated_ptr(const Alloc& alloc, Args&&... args)
+  wide_ptr(const Alloc& alloc, Args&&... args)
       : alloc_aware<Alloc>(alloc),
         indirect_ptr<inplace_ptr<T>>(allocate<inplace_ptr<T>>(
             this->alloc, std::in_place, std::forward<Args>(args)...)) {}
-  allocated_ptr(const allocated_ptr& rhs)
+  wide_ptr(const wide_ptr& rhs)
     requires(std::is_copy_constructible_v<T>)
       : alloc_aware<Alloc>(rhs),
         indirect_ptr<inplace_ptr<T>>(
             allocate<inplace_ptr<T>>(this->alloc, std::in_place, *rhs)) {}
-  allocated_ptr(allocated_ptr&& rhs) = delete;
-  ~allocated_ptr() noexcept(std::is_nothrow_destructible_v<T>) {
+  wide_ptr(wide_ptr&& rhs) = delete;
+  ~wide_ptr() noexcept(std::is_nothrow_destructible_v<T>) {
     deallocate(this->alloc, this->ptr_);
   }
 };
@@ -279,42 +279,31 @@ private:
   strong_weak_compact_ptr_storage<T, Alloc>* ptr_;
 };
 
-template <class F, class T, class Alloc, class... Args>
-constexpr proxy<F> allocate_proxy_impl(const Alloc& alloc, Args&&... args) {
-  if constexpr (proxiable<allocated_ptr<T, Alloc>, F>) {
-    return proxy<F>{std::in_place_type<allocated_ptr<T, Alloc>>, alloc,
-                    std::forward<Args>(args)...};
-  } else {
-    return proxy<F>{std::in_place_type<compact_ptr<T, Alloc>>, alloc,
-                    std::forward<Args>(args)...};
-  }
-}
-template <class F, class T, class... Args>
-constexpr proxy<F> make_proxy_impl(Args&&... args) {
-  if constexpr (proxiable<inplace_ptr<T>, F>) {
-    return proxy<F>{std::in_place_type<inplace_ptr<T>>, std::in_place,
-                    std::forward<Args>(args)...};
-  } else {
-    return allocate_proxy_impl<F, T>(std::allocator<void>{},
-                                     std::forward<Args>(args)...);
-  }
-}
-template <class F, class T, class Alloc, class... Args>
-constexpr proxy<F> allocate_proxy_shared_impl(const Alloc& alloc,
-                                              Args&&... args) {
-  if constexpr (std::is_convertible_v<proxy<F>, weak_proxy<F>>) {
-    return proxy<F>{std::in_place_type<strong_compact_ptr<T, Alloc>>, alloc,
-                    std::forward<Args>(args)...};
-  } else {
-    return proxy<F>{std::in_place_type<shared_compact_ptr<T, Alloc>>, alloc,
-                    std::forward<Args>(args)...};
-  }
-}
-template <class F, class T, class... Args>
-constexpr proxy<F> make_proxy_shared_impl(Args&&... args) {
-  return allocate_proxy_shared_impl<F, T>(std::allocator<void>{},
-                                          std::forward<Args>(args)...);
-}
+template <class F, class T, class Alloc>
+struct allocated_ptr_traits : std::type_identity<compact_ptr<T, Alloc>> {};
+template <class F, class T, class Alloc>
+  requires(proxiable<wide_ptr<T, Alloc>, F>)
+struct allocated_ptr_traits<F, T, Alloc>
+    : std::type_identity<wide_ptr<T, Alloc>> {};
+template <class F, class T, class Alloc>
+using allocated_ptr = allocated_ptr_traits<F, T, Alloc>::type;
+
+template <class F, class T>
+struct owned_ptr_traits : allocated_ptr_traits<F, T, std::allocator<void>> {};
+template <class F, class T>
+  requires(proxiable<inplace_ptr<T>, F>)
+struct owned_ptr_traits<F, T> : std::type_identity<inplace_ptr<T>> {};
+template <class F, class T>
+using owned_ptr = owned_ptr_traits<F, T>::type;
+
+template <class F, class T, class Alloc>
+struct shared_ptr_traits : std::type_identity<shared_compact_ptr<T, Alloc>> {};
+template <class F, class T, class Alloc>
+  requires(std::is_convertible_v<proxy<F>, weak_proxy<F>>)
+struct shared_ptr_traits<F, T, Alloc>
+    : std::type_identity<strong_compact_ptr<T, Alloc>> {};
+template <class F, class T, class Alloc = std::allocator<void>>
+using shared_ptr = shared_ptr_traits<F, T, Alloc>::type;
 
 } // namespace detail
 
@@ -328,7 +317,7 @@ template <class T>
 struct is_bitwise_trivially_relocatable<std::weak_ptr<T>> : std::true_type {};
 template <class T, class Alloc>
   requires(is_bitwise_trivially_relocatable_v<Alloc>)
-struct is_bitwise_trivially_relocatable<detail::allocated_ptr<T, Alloc>>
+struct is_bitwise_trivially_relocatable<detail::wide_ptr<T, Alloc>>
     : std::true_type {};
 template <class T, class Alloc>
 struct is_bitwise_trivially_relocatable<detail::compact_ptr<T, Alloc>>
@@ -343,52 +332,65 @@ template <class T, class Alloc>
 struct is_bitwise_trivially_relocatable<detail::weak_compact_ptr<T, Alloc>>
     : std::true_type {};
 
+template <facade F, class Alloc, class T>
+constexpr proxy<F> allocate_proxy(const Alloc& alloc, T&& value)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return proxy<F>{
+      std::in_place_type<detail::allocated_ptr<F, std::decay_t<T>, Alloc>>,
+      alloc, std::forward<T>(value)};
+}
 template <facade F, class T, class Alloc, class... Args>
 constexpr proxy<F> allocate_proxy(const Alloc& alloc, Args&&... args)
   requires(std::is_constructible_v<T, Args...>)
 {
-  return detail::allocate_proxy_impl<F, T>(alloc, std::forward<Args>(args)...);
+  return proxy<F>{std::in_place_type<detail::allocated_ptr<F, T, Alloc>>, alloc,
+                  std::forward<Args>(args)...};
 }
 template <facade F, class T, class Alloc, class U, class... Args>
 constexpr proxy<F> allocate_proxy(const Alloc& alloc,
                                   std::initializer_list<U> il, Args&&... args)
   requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
 {
-  return detail::allocate_proxy_impl<F, T>(alloc, il,
-                                           std::forward<Args>(args)...);
-}
-template <facade F, class Alloc, class T>
-constexpr proxy<F> allocate_proxy(const Alloc& alloc, T&& value)
-  requires(std::is_constructible_v<std::decay_t<T>, T>)
-{
-  return detail::allocate_proxy_impl<F, std::decay_t<T>>(
-      alloc, std::forward<T>(value));
-}
-template <facade F, class T, class... Args>
-constexpr proxy<F> make_proxy(Args&&... args)
-  requires(std::is_constructible_v<T, Args...>)
-{
-  return detail::make_proxy_impl<F, T>(std::forward<Args>(args)...);
-}
-template <facade F, class T, class U, class... Args>
-constexpr proxy<F> make_proxy(std::initializer_list<U> il, Args&&... args)
-  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
-{
-  return detail::make_proxy_impl<F, T>(il, std::forward<Args>(args)...);
+  return proxy<F>{std::in_place_type<detail::allocated_ptr<F, T, Alloc>>, alloc,
+                  il, std::forward<Args>(args)...};
 }
 template <facade F, class T>
 constexpr proxy<F> make_proxy(T&& value)
   requires(std::is_constructible_v<std::decay_t<T>, T>)
 {
-  return detail::make_proxy_impl<F, std::decay_t<T>>(std::forward<T>(value));
+  return proxy<F>{std::in_place_type<detail::owned_ptr<F, std::decay_t<T>>>,
+                  std::allocator<void>{}, std::forward<T>(value)};
+}
+template <facade F, class T, class... Args>
+constexpr proxy<F> make_proxy(Args&&... args)
+  requires(std::is_constructible_v<T, Args...>)
+{
+  return proxy<F>{std::in_place_type<detail::owned_ptr<F, T>>,
+                  std::allocator<void>{}, std::forward<Args>(args)...};
+}
+template <facade F, class T, class U, class... Args>
+constexpr proxy<F> make_proxy(std::initializer_list<U> il, Args&&... args)
+  requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
+{
+  return proxy<F>{std::in_place_type<detail::owned_ptr<F, T>>,
+                  std::allocator<void>{}, il, std::forward<Args>(args)...};
 }
 
+template <facade F, class Alloc, class T>
+constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc, T&& value)
+  requires(std::is_constructible_v<std::decay_t<T>, T>)
+{
+  return proxy<F>{
+      std::in_place_type<detail::shared_ptr<F, std::decay_t<T>, Alloc>>, alloc,
+      std::forward<T>(value)};
+}
 template <facade F, class T, class Alloc, class... Args>
 constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc, Args&&... args)
   requires(std::is_constructible_v<T, Args...>)
 {
-  return detail::allocate_proxy_shared_impl<F, T>(alloc,
-                                                  std::forward<Args>(args)...);
+  return proxy<F>{std::in_place_type<detail::shared_ptr<F, T, Alloc>>, alloc,
+                  std::forward<Args>(args)...};
 }
 template <facade F, class T, class Alloc, class U, class... Args>
 constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc,
@@ -396,35 +398,30 @@ constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc,
                                          Args&&... args)
   requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
 {
-  return detail::allocate_proxy_shared_impl<F, T>(alloc, il,
-                                                  std::forward<Args>(args)...);
+  return proxy<F>{std::in_place_type<detail::shared_ptr<F, T, Alloc>>, alloc,
+                  il, std::forward<Args>(args)...};
 }
-template <facade F, class Alloc, class T>
-constexpr proxy<F> allocate_proxy_shared(const Alloc& alloc, T&& value)
+template <facade F, class T>
+constexpr proxy<F> make_proxy_shared(T&& value)
   requires(std::is_constructible_v<std::decay_t<T>, T>)
 {
-  return detail::allocate_proxy_shared_impl<F, std::decay_t<T>>(
-      alloc, std::forward<T>(value));
+  return proxy<F>{std::in_place_type<detail::shared_ptr<F, std::decay_t<T>>>,
+                  std::allocator<void>{}, std::forward<T>(value)};
 }
 template <facade F, class T, class... Args>
 constexpr proxy<F> make_proxy_shared(Args&&... args)
   requires(std::is_constructible_v<T, Args...>)
 {
-  return detail::make_proxy_shared_impl<F, T>(std::forward<Args>(args)...);
+  return proxy<F>{std::in_place_type<detail::shared_ptr<F, T>>,
+                  std::allocator<void>{}, std::forward<Args>(args)...};
 }
 template <facade F, class T, class U, class... Args>
 constexpr proxy<F> make_proxy_shared(std::initializer_list<U> il,
                                      Args&&... args)
   requires(std::is_constructible_v<T, std::initializer_list<U>&, Args...>)
 {
-  return detail::make_proxy_shared_impl<F, T>(il, std::forward<Args>(args)...);
-}
-template <facade F, class T>
-constexpr proxy<F> make_proxy_shared(T&& value)
-  requires(std::is_constructible_v<std::decay_t<T>, T>)
-{
-  return detail::make_proxy_shared_impl<F, std::decay_t<T>>(
-      std::forward<T>(value));
+  return proxy<F>{std::in_place_type<detail::shared_ptr<F, T>>,
+                  std::allocator<void>{}, il, std::forward<Args>(args)...};
 }
 #endif // __STDC_HOSTED__
 

--- a/tests/proxy_creation_tests.cpp
+++ b/tests/proxy_creation_tests.cpp
@@ -12,7 +12,7 @@ namespace proxy_creation_tests_detail {
 enum LifetimeModelType {
   kNone,
   kInplace,
-  kAllocated,
+  kWide,
   kCompact,
   kSharedCompact,
   kStrongCompact
@@ -25,8 +25,8 @@ struct LifetimeModelReflector {
       : Type(LifetimeModelType::kInplace) {}
   template <class T, class Alloc>
   constexpr explicit LifetimeModelReflector(
-      std::in_place_type_t<pro::detail::allocated_ptr<T, Alloc>>)
-      : Type(LifetimeModelType::kAllocated) {}
+      std::in_place_type_t<pro::detail::wide_ptr<T, Alloc>>)
+      : Type(LifetimeModelType::kWide) {}
   template <class T, class Alloc>
   constexpr explicit LifetimeModelReflector(
       std::in_place_type_t<pro::detail::compact_ptr<T, Alloc>>)
@@ -293,7 +293,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_FromValue) {
         std::allocator<void>{}, session);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 2");
-    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(2,
                               utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -311,7 +311,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_InPlace) {
         std::allocator<void>{}, &tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
-    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(1,
                               utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -330,7 +330,7 @@ TEST(ProxyCreationTests,
         std::allocator<void>{}, {1, 2, 3}, &tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
-    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(
         1, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -351,10 +351,10 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_Lifetime_Copy) {
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
     ASSERT_EQ(ToString(*p1), "Session 1");
-    ASSERT_EQ(p1.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p1.GetLifetimeType(), detail::LifetimeModelType::kWide);
     ASSERT_TRUE(p2.has_value());
     ASSERT_EQ(ToString(*p2), "Session 2");
-    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(2,
                               utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -377,7 +377,7 @@ TEST(ProxyCreationTests, TestAllocateProxy_DirectAllocator_Lifetime_Move) {
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
     ASSERT_EQ(ToString(*p2), "Session 1");
-    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kWide);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);
@@ -601,7 +601,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_FromValue) {
     auto p = pro::make_proxy<detail::TestSmallStringable>(session);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 2");
-    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(2,
                               utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -618,7 +618,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_InPlace) {
                              utils::LifetimeTracker::Session>(&tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
-    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(1,
                               utils::LifetimeOperationType::kValueConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -636,7 +636,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_InPlaceInitializerList) {
                         utils::LifetimeTracker::Session>({1, 2, 3}, &tracker);
     ASSERT_TRUE(p.has_value());
     ASSERT_EQ(ToString(*p), "Session 1");
-    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(
         1, utils::LifetimeOperationType::kInitializerListConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -656,10 +656,10 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_Lifetime_Copy) {
     auto p2 = p1;
     ASSERT_TRUE(p1.has_value());
     ASSERT_EQ(ToString(*p1), "Session 1");
-    ASSERT_EQ(p1.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p1.GetLifetimeType(), detail::LifetimeModelType::kWide);
     ASSERT_TRUE(p2.has_value());
     ASSERT_EQ(ToString(*p2), "Session 2");
-    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kWide);
     expected_ops.emplace_back(2,
                               utils::LifetimeOperationType::kCopyConstruction);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
@@ -681,7 +681,7 @@ TEST(ProxyCreationTests, TestMakeProxy_WithoutSBO_Lifetime_Move) {
     ASSERT_FALSE(p1.has_value());
     ASSERT_TRUE(p2.has_value());
     ASSERT_EQ(ToString(*p2), "Session 1");
-    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kAllocated);
+    ASSERT_EQ(p2.GetLifetimeType(), detail::LifetimeModelType::kWide);
     ASSERT_TRUE(tracker.GetOperations() == expected_ops);
   }
   expected_ops.emplace_back(1, utils::LifetimeOperationType::kDestruction);


### PR DESCRIPTION
Replace the `*_impl` proxy creation functions with type traits that name the selected lifetime model, so that the models can be reused by types other than `proxy` (e.g. an upcoming `box` in v5). No observable behavior change.

- Rename the internal `allocated_ptr` class template to `wide_ptr`, and add `allocated_ptr`, `owned_ptr` and `shared_ptr` type traits that select a lifetime model instead of constructing a `proxy` directly. The creation functions now construct `proxy<F>` from the selected pointer type.
- Let `inplace_ptr` ignore its first constructor argument so that all owning lifetime models share a uniform `(alloc, args...)` construction signature.
- Order the `T&& value` overload first in each creation function family, and renumber the corresponding specs to match.