### PR TITLE
Align compilation flags across build systems

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -3,6 +3,7 @@ common --enable_bzlmod
 common --enable_platform_specific_config
 
 # Default Build Options
+build --compilation_mode=opt
 build --features=external_include_paths
 
 # Freestanding Configuration

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ if(PROJECT_IS_TOP_LEVEL)
   )
 endif()
 
+set(CMAKE_CXX_EXTENSIONS OFF)
+
 if(PROXY_FREESTANDING)
   add_compile_options(-ffreestanding -fno-exceptions -fno-rtti)
   add_link_options(-nodefaultlibs -lc)
@@ -120,7 +122,7 @@ if(BUILD_TESTING)
       -Wall
       -Wextra
       -Wpedantic
-      $<$<CXX_COMPILER_ID:Clang>:-Wno-c++2b-extensions>
+      $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-c++2b-extensions>
     )
     set(PROXY_STRICT_WARNING_FLAGS ${PROXY_BUILD_FLAGS} -Werror)
   endif()

--- a/cmake/msft_proxy4ModuleTargets.cmake
+++ b/cmake/msft_proxy4ModuleTargets.cmake
@@ -29,6 +29,6 @@ target_compile_options(
   msft_proxy4_module
   PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/utf-8>
-    $<$<CXX_COMPILER_ID:Clang>:-Wno-c++2b-extensions>
+    $<$<CXX_COMPILER_ID:Clang,AppleClang>:-Wno-c++2b-extensions>
 )
 target_link_libraries(msft_proxy4_module PUBLIC msft_proxy4::proxy)

--- a/meson.build
+++ b/meson.build
@@ -6,6 +6,7 @@ project(
   license_files: 'LICENSE',
   meson_version: '>=1.3',
   default_options: {
+    'b_ndebug': 'if-release',
     'cpp_std': ['vc++latest', 'c++26', 'c++23', 'c++20'],
     'warning_level': '3',
   },


### PR DESCRIPTION
**Changes**

- Set `CMAKE_CXX_EXTENSIONS` to `OFF`. It defaults to `ON`, so CMake was the only toolchain compiling in GNU extension mode, `-std=gnu++20` against `-std=c++26` under Meson and `-std=c++20` under Bazel. No effect on MSVC, where CMake maps standard and extension to the same `-std:c++20`.
- Added `AppleClang` to the `-Wno-c++2b-extensions` generator expressions in `CMakeLists.txt` and `cmake/msft_proxy4ModuleTargets.cmake`. `CXX_COMPILER_ID` reports `AppleClang` rather than `Clang`, while Meson and Bazel both classify it as clang.
- Defined `NDEBUG` consistently by setting `b_ndebug` in Meson and `--compilation_mode=opt` in Bazel. Only CMake defined it before, leaving `PRO4D_DEBUG` and `assert` compiled in under the other two.