### PR TITLE
Convert out-of-line metadata into inline metadata storage

### DIFF
--- a/include/proxy/v4/detail/facade_meta_traits.h
+++ b/include/proxy/v4/detail/facade_meta_traits.h
@@ -171,13 +171,13 @@ struct inplace_meta_storage : M {
     requires(std::is_nothrow_convertible_v<const M2&, const M&>)
   inplace_meta_storage&
       operator=(const inplace_meta_storage<M2>& rhs) noexcept {
-    static_cast<M&>(*this) = *rhs;
+    M::operator=(*rhs);
     return *this;
   }
   template <class M2>
     requires(std::is_nothrow_convertible_v<const M2&, const M&>)
   inplace_meta_storage& operator=(const static_meta_storage<M2>& rhs) noexcept {
-    static_cast<M&>(*this) = *rhs;
+    M::operator=(*rhs);
     return *this;
   }
 

--- a/include/proxy/v4/detail/facade_meta_traits.h
+++ b/include/proxy/v4/detail/facade_meta_traits.h
@@ -141,43 +141,17 @@ PRO4D_DEF_OVERLOAD_SPECIALIZATIONS(PRO4D_DEF_INVOKER)
 #undef PRO4D_DEF_INVOKER
 
 template <class M>
-struct PRO4D_ENFORCE_EBO inplace_meta_storage : M {
-  using M::M;
-
-  inplace_meta_storage() = default;
-  inplace_meta_storage(const inplace_meta_storage&) = default;
-  template <class M2>
-    requires(std::is_nothrow_convertible_v<const M2&, const M&>)
-  inplace_meta_storage(const inplace_meta_storage<M2>& rhs) noexcept
-      : M(static_cast<const M&>(*rhs)) {}
-  inplace_meta_storage& operator=(const inplace_meta_storage&) = default;
-  template <class M2>
-    requires(std::is_nothrow_convertible_v<const M2&, const M&>)
-  inplace_meta_storage&
-      operator=(const inplace_meta_storage<M2>& rhs) noexcept {
-    static_cast<M&>(*this) = static_cast<const M&>(*rhs);
-    return *this;
-  }
-
-  const M& operator*() const noexcept { return *this; }
-};
-
-template <class M>
 struct static_meta_storage {
   static_meta_storage() = default;
-  template <class M2>
-    requires(std::is_nothrow_convertible_v<const M2&, const M&>)
-  static_meta_storage(const static_meta_storage<M2>& rhs) noexcept
-      : ptr_(std::addressof(static_cast<const M&>(*rhs))) {}
+  template <class P>
+  explicit static_meta_storage(std::in_place_type_t<P>)
+      : ptr_(std::addressof(storage<P>)) {}
   template <class M2>
     requires(std::is_nothrow_convertible_v<const M2&, const M&>)
   static_meta_storage& operator=(const static_meta_storage<M2>& rhs) noexcept {
     ptr_ = std::addressof(static_cast<const M&>(*rhs));
     return *this;
   }
-  template <class P>
-  explicit static_meta_storage(std::in_place_type_t<P>)
-      : ptr_(std::addressof(storage<P>)) {}
   bool has_value() const noexcept { return ptr_ != nullptr; }
   void reset() noexcept { ptr_ = nullptr; }
   const M& operator*() const noexcept { return *ptr_; }
@@ -187,6 +161,27 @@ private:
 
   template <class P>
   static inline const M storage{std::in_place_type<P>};
+};
+
+template <class M>
+struct inplace_meta_storage : M {
+  using M::M;
+
+  template <class M2>
+    requires(std::is_nothrow_convertible_v<const M2&, const M&>)
+  inplace_meta_storage&
+      operator=(const inplace_meta_storage<M2>& rhs) noexcept {
+    static_cast<M&>(*this) = *rhs;
+    return *this;
+  }
+  template <class M2>
+    requires(std::is_nothrow_convertible_v<const M2&, const M&>)
+  inplace_meta_storage& operator=(const static_meta_storage<M2>& rhs) noexcept {
+    static_cast<M&>(*this) = *rhs;
+    return *this;
+  }
+
+  const M& operator*() const noexcept { return *this; }
 };
 
 } // namespace detail

--- a/tests/proxy_lifetime_tests.cpp
+++ b/tests/proxy_lifetime_tests.cpp
@@ -1217,6 +1217,32 @@ TEST(ProxyLifetimeTests, Test_CopySubstitution_FromNull) {
   ASSERT_FALSE(p2.has_value());
 }
 
+TEST(ProxyLifetimeTests, Test_CopySubstitution_MixedMetaStorage) {
+  struct Super : pro::facade_builder //
+                 ::add_convention<utils::spec::FreeToString,
+                                  std::string() const>                 //
+                 ::support_copy<pro::constraint_level::trivial>        //
+                 ::support_relocation<pro::constraint_level::trivial>  //
+                 ::support_destruction<pro::constraint_level::trivial> //
+                 ::build {};
+  struct Derived : pro::facade_builder                   //
+                   ::add_facade_with_substitution<Super> //
+                   ::build {};
+  static_assert(
+      pro::detail::specialization_of<pro::compact_facade_meta_traits::storage<
+                                         pro::detail::proxy_meta<Super>>,
+                                     pro::detail::inplace_meta_storage>);
+  static_assert(
+      pro::detail::specialization_of<pro::compact_facade_meta_traits::storage<
+                                         pro::detail::proxy_meta<Derived>>,
+                                     pro::detail::static_meta_storage>);
+  int v = 123;
+  pro::proxy<Derived> p1 = &v;
+  pro::proxy<Super> p2 = p1;
+  ASSERT_EQ(ToString(*p1), "123");
+  ASSERT_EQ(ToString(*p2), "123");
+}
+
 TEST(ProxyLifetimeTests, Test_MoveSubstitution_FromValue) {
   utils::LifetimeTracker tracker;
   std::vector<utils::LifetimeOperation> expected_ops;


### PR DESCRIPTION
**Changes**

- Added a converting assignment to `inplace_meta_storage` from `static_meta_storage`, so metadata held out of line can be carried into a proxy whose own metadata is held inline.
- Moved `static_meta_storage` ahead of `inplace_meta_storage`, which is what lets the new assignment name it.
- Added a substitution test (will cover this path after #74).

Resolves #75 