### PR TITLE
Refuse a mutable proxy_cast on a const contained value

### DIFF
--- a/include/proxy/v4/detail/skills.h
+++ b/include/proxy/v4/detail/skills.h
@@ -205,7 +205,8 @@ struct proxy_cast_dispatch {
     if (typeid(T) == *ctx.type_ptr) [[likely]] {
       if (ctx.is_ref) {
         if constexpr (std::is_lvalue_reference_v<T>) {
-          if (ctx.is_const || !std::is_const_v<T>) [[likely]] {
+          if (ctx.is_const || !std::is_const_v<std::remove_reference_t<T>>)
+              [[likely]] {
             *static_cast<void**>(ctx.result_ptr) = (void*)std::addressof(self);
           }
         }

--- a/tests/proxy_rtti_tests.cpp
+++ b/tests/proxy_rtti_tests.cpp
@@ -131,6 +131,26 @@ TEST(ProxyRttiTests, TestIndirectCast_ConstPtr_Fail) {
   ASSERT_EQ(v, 123);
 }
 
+TEST(ProxyRttiTests, TestIndirectCast_Ref_ConstTarget) {
+  const auto p = pro::make_proxy<detail::TestFacade, int>(123);
+  bool exception_thrown = false;
+  try {
+    proxy_cast<int&>(*p);
+  } catch (const pro::bad_proxy_cast&) {
+    exception_thrown = true;
+  }
+  ASSERT_TRUE(exception_thrown);
+  ASSERT_EQ(proxy_cast<const int&>(*p), 123);
+}
+
+TEST(ProxyRttiTests, TestIndirectCast_Ptr_ConstTarget) {
+  const auto p = pro::make_proxy<detail::TestFacade, int>(123);
+  ASSERT_EQ(proxy_cast<int>(&*p), nullptr);
+  auto ptr = proxy_cast<const int>(&*p);
+  static_assert(std::is_same_v<decltype(ptr), const int*>);
+  ASSERT_EQ(*ptr, 123);
+}
+
 TEST(ProxyRttiTests, TestIndirectTypeid) {
   int a = 123;
   pro::proxy<detail::TestFacade> p = &a;


### PR DESCRIPTION
**Changes**

- Fixed the constness guard in `proxy_cast_dispatch` to test the referenced type rather than the reference, so a const contained value is no longer reachable mutably.
- Added `TestIndirectCast_Ref_ConstTarget` and `TestIndirectCast_Ptr_ConstTarget`, covering the value form and the pointer form.

`proxy_cast<int&>` on a proxy whose contained value is const now throws `bad_proxy_cast`, and the pointer form returns `nullptr`, which is what the const qualified overload already promised. Reaching a const contained value still works by asking for it as const.

Resolves #79