### PR TITLE
Reduce direct RTTI to a single reflection

### DIFF
--- a/include/proxy/v4/detail/skills.h
+++ b/include/proxy/v4/detail/skills.h
@@ -163,7 +163,7 @@ struct proxy_cast_accessor_impl {
                              .is_ref = true,
                              .is_const = std::is_const_v<U>,
                              .result_ptr = &result};
-      invoke<D, O>(static_cast<Self>(self), ctx);
+      invoke_cast<T>(static_cast<Self>(self), ctx);
       if (result == nullptr) [[unlikely]] {
         PRO4D_THROW(bad_proxy_cast{});
       }
@@ -174,7 +174,7 @@ struct proxy_cast_accessor_impl {
                              .is_ref = false,
                              .is_const = false,
                              .result_ptr = &result};
-      invoke<D, O>(static_cast<Self>(self), ctx);
+      invoke_cast<T>(static_cast<Self>(self), ctx);
       if (!result.has_value()) [[unlikely]] {
         PRO4D_THROW(bad_proxy_cast{});
       }
@@ -190,8 +190,31 @@ struct proxy_cast_accessor_impl {
                            .is_ref = true,
                            .is_const = std::is_const_v<T>,
                            .result_ptr = &result};
-    invoke<D, O>(*self, ctx);
+    invoke_cast<T>(*self, ctx);
     return static_cast<T*>(result);
+  }
+
+private:
+  template <class T>
+  static void invoke_cast(Self self, const proxy_cast_context& cast_ctx) {
+    if constexpr (specialization_of<std::remove_cvref_t<Self>, proxy>) {
+      using F = std::remove_cvref_t<Self>::facade_type;
+      constexpr bool is_rv =
+          overload_traits<O>::this_qualifier == qualifier_type::rv;
+      if (proxy_typeid(self) == *cast_ctx.type_ptr) [[likely]] {
+        erased_context<true, D, O> ctx{proxy_helper::get_ptr(self)};
+        if constexpr (is_rv) {
+          proxy_helper::meta_resetting_guard<F> guard{self};
+          invoke<std::decay_t<T>>(ctx, cast_ctx);
+        } else {
+          invoke<std::decay_t<T>>(ctx, cast_ctx);
+        }
+      } else if constexpr (is_rv) {
+        self.reset();
+      }
+    } else {
+      invoke<D, O>(static_cast<Self>(self), cast_ctx);
+    }
   }
 };
 
@@ -242,6 +265,17 @@ struct proxy_typeid_reflector {
 
   const std::type_info* info;
 };
+
+struct direct_rtti_reflector : proxy_typeid_reflector {
+  using proxy_typeid_reflector::proxy_typeid_reflector;
+
+  template <class Self, class R>
+  struct PRO4D_ENFORCE_EBO accessor
+      : proxy_typeid_reflector::accessor<Self, R>,
+        proxy_cast_dispatch::accessor<
+            Self, proxy_cast_dispatch, void(proxy_cast_context) &,
+            void(proxy_cast_context) const&, void(proxy_cast_context) &&> {};
+};
 #endif // __cpp_rtti >= 199711L
 
 } // namespace detail
@@ -270,11 +304,7 @@ using indirect_rtti = FB::template add_indirect_convention<
 
 template <class FB>
 using direct_rtti =
-    FB::template add_direct_convention<detail::proxy_cast_dispatch,
-                                       void(detail::proxy_cast_context) &,
-                                       void(detail::proxy_cast_context) const&,
-                                       void(detail::proxy_cast_context) &&>::
-        template add_direct_reflection<detail::proxy_typeid_reflector>;
+    FB::template add_direct_reflection<detail::direct_rtti_reflector>;
 
 template <class FB>
 using rtti = indirect_rtti<FB>;


### PR DESCRIPTION
`skills::direct_rtti` installed three conventions to carry `proxy_cast`, so every proxiable pointer paid three function pointers of metadata and every cast went through one of them. The typeid reflection that the same skill already installs records the contained type, and once that type is known to match the requested one the cast is a `static_cast` on the pointer storage, so the indirection buys nothing.

**Changes**

- Reduced `skills::direct_rtti` to a single reflection, because the reflection it already installed is enough to identify the contained type.
- Added `direct_rtti_reflector`, which inherits `proxy_typeid_reflector` for the type identity and reuses the accessor generated for `proxy_cast_dispatch`, so the five `proxy_cast` overloads and their qualifier mapping stay in one place.
- Added a private `invoke_cast` to `proxy_cast_accessor_impl`, which tests the reflected type and then invokes the same dispatch through an erased context with the contained type known statically. The indirect path is unchanged and compiles to the same code as before.

**Effect**

Metadata for a facade built from `direct_rtti` alone drops from 40 bytes to 16. Measured on `feature/v5` with g++-16 at `-O2` on aarch64.

| cast | before | after |
| --- | --- | --- |
| lvalue | 46 instructions, 1 indirect call | 27 instructions, no indirect call |
| pointer | 37 instructions, 1 indirect call | 29 instructions, no indirect call |
| rvalue | 66 instructions, 1 indirect call | 34 instructions, 1 indirect call |

The indirect call remaining in the rvalue form sits on the type mismatch branch, where the proxy is reset through the erased destructor. The success path has none.

The existing RTTI tests pass unchanged, so no test was added or modified.